### PR TITLE
#30 add-leagueコンポーネントにManual欄を追加

### DIFF
--- a/src/app/pages/add-league/add-league.component.html
+++ b/src/app/pages/add-league/add-league.component.html
@@ -18,13 +18,13 @@
             </mat-radio-group>
         </div>
     </div>
-    <div *ngIf="formGroup.get('rulesRadio')?.value === 'mahjongsoulRules'">
+    <ng-container *ngIf="formGroup.get('rulesRadio')?.value === 'mahjongsoulRules'">
         <app-rules [rulesRadioValue]="formGroup.get('rulesRadio')?.value" (sendRules)="setRules($event)"></app-rules>
-    </div>
-    <div *ngIf="formGroup.get('rulesRadio')?.value === 'tenhouRules'">
+    </ng-container>
+    <ng-container *ngIf="formGroup.get('rulesRadio')?.value === 'tenhouRules'">
         <app-rules [rulesRadioValue]="formGroup.get('rulesRadio')?.value" (sendRules)="setRules($event)"></app-rules>
-    </div>
-    <div *ngIf="formGroup.get('rulesRadio')?.value === 'custom'">
+    </ng-container>
+    <ng-container *ngIf="formGroup.get('rulesRadio')?.value === 'custom'">
         <app-rules [rulesRadioValue]="formGroup.get('rulesRadio')?.value" (sendRules)="setRules($event)"></app-rules>
-    </div>
+    </ng-container>
 </form>

--- a/src/app/pages/add-league/add-league.component.html
+++ b/src/app/pages/add-league/add-league.component.html
@@ -4,7 +4,11 @@
         <p>大会名</p>
         <mat-form-field class="league__input" appearance="outline">
             <mat-label>大会名</mat-label>
-            <input matInput placeholder="" value="" formControlName="leagueInput" />
+            <input matInput placeholder="" value="" formControlName="leagueName" />
+        </mat-form-field>
+        <mat-form-field class="league__input" appearance="outline">
+            <mat-label>大会説明</mat-label>
+            <textarea matInput placeholder="" value="" formControlName="leagueManual"></textarea>
         </mat-form-field>
         <div class="league__radio">
             <mat-radio-group formControlName="rulesRadio">

--- a/src/app/pages/add-league/add-league.component.html
+++ b/src/app/pages/add-league/add-league.component.html
@@ -4,11 +4,11 @@
         <p>大会名</p>
         <mat-form-field class="league__input" appearance="outline">
             <mat-label>大会名</mat-label>
-            <input matInput placeholder="" value="" formControlName="leagueName" />
+            <input matInput placeholder="" value="" formControlName="leagueName" maxlength="40" />
         </mat-form-field>
         <mat-form-field class="league__input" appearance="outline">
             <mat-label>大会説明</mat-label>
-            <textarea matInput placeholder="" value="" formControlName="leagueManual"></textarea>
+            <textarea matInput placeholder="" value="" formControlName="leagueManual" maxlength="100"></textarea>
         </mat-form-field>
         <div class="league__radio">
             <mat-radio-group formControlName="rulesRadio">

--- a/src/app/pages/add-league/add-league.component.ts
+++ b/src/app/pages/add-league/add-league.component.ts
@@ -11,7 +11,8 @@ import { RulesService } from '../../shared/services/rules.service';
 })
 export class AddLeagueComponent implements OnInit {
   formGroup = new FormGroup({
-    leagueInput: new FormControl('', [Validators.required]),
+    leagueName: new FormControl('', [Validators.required]),
+    leagueManual: new FormControl('', []),
     rulesRadio: new FormControl('', [Validators.required]),
   });
 


### PR DESCRIPTION
# Issue 
#30
# 新規/変更内容
add-leagueに大会説明用のtextareaを追加
仮のmaxlengthを追加(DB完成時に見直す予定)
rulesを表示しているdivをng-containerに変更
