### PR TITLE
#43 tableの構成を変更

### DIFF
--- a/src/app/pages/player-details/player-details.component.html
+++ b/src/app/pages/player-details/player-details.component.html
@@ -19,5 +19,5 @@
     <div class="material grid-item__pie">
         <app-pie-chart [pieData]="pieData"></app-pie-chart>
     </div>
-    <div class="material grid-item__table"><app-table [results]="tableData"></app-table></div>
+    <div class="material grid-item__table"><app-table [columns]="tableColumns" [results]="tableData"></app-table></div>
 </div>

--- a/src/app/pages/player-details/player-details.component.ts
+++ b/src/app/pages/player-details/player-details.component.ts
@@ -12,6 +12,7 @@ export class PlayerDetailsComponent implements OnInit {
   lineLabels: string[] = [];
   lineData: number[] = [];
   pieData: number[] = [];
+  tableColumns: string[] = [];
   tableData: ResultTableWrapper[] = [];
   constructor() {}
 
@@ -33,6 +34,7 @@ export class PlayerDetailsComponent implements OnInit {
     ];
     this.lineData = [1, 1, 3, 2, 4, 2, 3, 1, 4, 4];
     this.pieData = [10, 9, 8, 7];
+    this.tableColumns = ['rank', 'point', 'calcPoint', 'date'];
     this.tableData = [
       {
         rank: '1位',

--- a/src/app/pages/player-details/player-details.component.ts
+++ b/src/app/pages/player-details/player-details.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { PlayerResultWrapper } from '../../shared/interfaces/result';
 
 @Component({
   selector: 'app-player-details',
@@ -13,7 +14,7 @@ export class PlayerDetailsComponent implements OnInit {
   lineData: number[] = [];
   pieData: number[] = [];
   tableColumns: string[] = [];
-  tableData: ResultTableWrapper[] = [];
+  tableData: PlayerResultWrapper[] = [];
   constructor() {}
 
   ngOnInit(): void {
@@ -64,15 +65,4 @@ export class PlayerDetailsComponent implements OnInit {
       },
     ];
   }
-}
-
-interface ResultTable {
-  rank: string;
-  point: number;
-  calcPoint: number;
-  date: Date;
-  group: number;
-}
-interface ResultTableWrapper extends ResultTable {
-  resultData: ResultTable[];
 }

--- a/src/app/shared/components/table/table.component.html
+++ b/src/app/shared/components/table/table.component.html
@@ -1,8 +1,13 @@
 <table mat-table [dataSource]="dataSource" multiTemplateDataRows class="table">
     <ng-container matColumnDef="{{ column }}" *ngFor="let column of columnsToDisplay">
         <th class="table__header" mat-header-cell *matHeaderCellDef>{{ column | japanese }}</th>
-        <td mat-cell *matCellDef="let element">
-            {{ column === "date" ? (element[column] | date: "yyyy/MM/dd HH:mm") : element[column] }}
+        <td class="table__cell" mat-cell *matCellDef="let element">
+            <ng-container *ngIf="column !== 'playerName'">
+                {{ column === "date" ? (element[column] | date: "yyyy/MM/dd HH:mm") : element[column] }}
+            </ng-container>
+            <ng-container *ngIf="column === 'playerName'">
+                <a routerLink="/player/{{ element.playerId }}">{{ element[column] }}</a>
+            </ng-container>
         </td>
     </ng-container>
     <ng-container matColumnDef="expandedDetail">

--- a/src/app/shared/components/table/table.component.scss
+++ b/src/app/shared/components/table/table.component.scss
@@ -1,3 +1,5 @@
+@use "variable" as var;
+
 .table {
   width: 100%;
 
@@ -6,6 +8,13 @@
     font-weight: 100;
     width: 20%;
   }
+
+  &__cell {
+    a {
+      color: var.$normalFontColor;
+    }
+  }
+
   &__element-row {
     &:not(.expanded-row):hover {
       background: whitesmoke;

--- a/src/app/shared/components/table/table.component.ts
+++ b/src/app/shared/components/table/table.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Result } from '../../interfaces/result';
+import { PlayerResult, PlayerResultWrapper } from '../../interfaces/result';
 
 @Component({
   selector: 'app-table',
@@ -16,10 +16,10 @@ import { Result } from '../../interfaces/result';
 })
 export class TableComponent implements OnInit {
   @Input('columns') columns!: string[];
-  @Input('results') results!: ResultTableWrapper[];
+  @Input('results') results!: PlayerResultWrapper[];
   dataSource = [{}];
   columnsToDisplay: string[] = [];
-  expandedElement?: ResultTable | null;
+  expandedElement?: PlayerResult | null;
 
   constructor() {}
 
@@ -27,15 +27,4 @@ export class TableComponent implements OnInit {
     this.columnsToDisplay = this.columns;
     this.dataSource = this.results;
   }
-}
-
-interface ResultTable {
-  rank: string;
-  point: number;
-  calcPoint: number;
-  date: Date;
-  group: number;
-}
-interface ResultTableWrapper extends ResultTable {
-  resultData: ResultTable[];
 }

--- a/src/app/shared/components/table/table.component.ts
+++ b/src/app/shared/components/table/table.component.ts
@@ -15,14 +15,16 @@ import { Result } from '../../interfaces/result';
   ],
 })
 export class TableComponent implements OnInit {
+  @Input('columns') columns!: string[];
   @Input('results') results!: ResultTableWrapper[];
   dataSource = [{}];
-  columnsToDisplay: string[] = ['rank', 'point', 'calcPoint', 'date'];
+  columnsToDisplay: string[] = [];
   expandedElement?: ResultTable | null;
 
   constructor() {}
 
   ngOnInit(): void {
+    this.columnsToDisplay = this.columns;
     this.dataSource = this.results;
   }
 }

--- a/src/app/shared/components/table/table.component.ts
+++ b/src/app/shared/components/table/table.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { PlayerResult, PlayerResultWrapper } from '../../interfaces/result';
+import { PlayerResult, PlayerResultWrapper, LeagueResult } from '../../interfaces/result';
 
 @Component({
   selector: 'app-table',
@@ -16,7 +16,7 @@ import { PlayerResult, PlayerResultWrapper } from '../../interfaces/result';
 })
 export class TableComponent implements OnInit {
   @Input('columns') columns!: string[];
-  @Input('results') results!: PlayerResultWrapper[];
+  @Input('results') results!: PlayerResultWrapper[] | LeagueResult[];
   dataSource = [{}];
   columnsToDisplay: string[] = [];
   expandedElement?: PlayerResult | null;

--- a/src/app/shared/interfaces/result.ts
+++ b/src/app/shared/interfaces/result.ts
@@ -12,3 +12,14 @@ export interface Result {
   calcPoint3: number;
   calcPoint4: number;
 }
+
+export interface PlayerResult {
+  rank: string;
+  point: number;
+  calcPoint: number;
+  date: Date;
+  group: number;
+}
+export interface PlayerResultWrapper extends PlayerResult {
+  resultData: PlayerResult[];
+}

--- a/src/app/shared/interfaces/result.ts
+++ b/src/app/shared/interfaces/result.ts
@@ -23,3 +23,12 @@ export interface PlayerResult {
 export interface PlayerResultWrapper extends PlayerResult {
   resultData: PlayerResult[];
 }
+
+export interface LeagueResult {
+  rank: string;
+  plyerId: string;
+  playerName: string;
+  totalGameCount: number;
+  totalCalcPoint: number;
+  date: Date;
+}

--- a/src/app/shared/pipes/japanese.pipe.ts
+++ b/src/app/shared/pipes/japanese.pipe.ts
@@ -14,6 +14,12 @@ export class JapanesePipe implements PipeTransform {
         return (value = '順位点');
       case 'date':
         return (value = '日付');
+      case 'playerName':
+        return (value = 'プレイヤー名');
+      case 'totalGameCount':
+        return (value = '対戦回数');
+      case 'totalCalcPoint':
+        return (value = '順位点合計');
       default:
         return value;
     }


### PR DESCRIPTION
# Issue 
#43
# 新規/変更内容
tableコンポーネントでcolmunsDataとleagueResult、playerResultを受け取れるように変更
playerNameクリックでplayerDatailsに遷移する変更
japanesePipeにleagueResut用の変換を追加

# 備考
テーブル要素の表示が冗長な部分があるので解決策があればリファクタリングする