### PR TITLE
#54 league-detailsのデザインを変更

### DIFF
--- a/src/app/pages/league-details/league-details.component.html
+++ b/src/app/pages/league-details/league-details.component.html
@@ -2,27 +2,40 @@
   <p>{{ leagueName }}</p>
 </div>
 
-<div class="league">
-  <p class="league__title">大会期間</p>
+<ng-container>
+  <div class="league-buttons">
+    <button
+      class="league-buttons__button"
+      mat-stroked-button
+      color="accent"
+      routerLink="/league/add-player/{{ leagueId }}"
+    >
+      プレイヤー追加
+    </button>
+    <button class="league-buttons__button" mat-stroked-button color="accent" routerLink="/add-result/{{ leagueId }}">
+      成績追加
+    </button>
+  </div>
+</ng-container>
+
+<div class="league-details">
+  <p class="league-details__title">大会期間</p>
   <mat-divider></mat-divider>
-  <p class="league__content">
+  <p class="league-details__content">
     {{ leagueStartAt | date: 'yyyy/MM/dd HH:mm' }} ~
     {{ leagueFnishAt | date: 'yyyy/MM/dd HH:mm' }}
   </p>
-  <p class="league__title">大会説明</p>
+  <p class="league-details__title">大会説明</p>
   <mat-divider></mat-divider>
-  <p class="league__content">{{ leagueManual }}</p>
-
-  <div class="league-rules-toggle">
-    <p class="league__title">
-      ルール
-      <mat-slide-toggle (change)="isRules = isRules === false ? true : false"></mat-slide-toggle>
-    </p>
-    <mat-divider></mat-divider>
-    <ng-container *ngIf="isRules">
-      <app-rule-list [rules]="rules"></app-rule-list>
-    </ng-container>
-  </div>
+  <p class="league-details__content">{{ leagueManual }}</p>
+  <p class="league-details__title">
+    ルール
+    <mat-slide-toggle (change)="isRules = isRules === false ? true : false"></mat-slide-toggle>
+  </p>
+  <mat-divider></mat-divider>
+  <ng-container *ngIf="isRules">
+    <app-rule-list [rules]="rules"></app-rule-list>
+  </ng-container>
 </div>
 <div class="material league-table">
   <app-table [columns]="tableColumns" [results]="tableData"></app-table>

--- a/src/app/pages/league-details/league-details.component.html
+++ b/src/app/pages/league-details/league-details.component.html
@@ -2,38 +2,17 @@
   <p>{{ leagueName }}</p>
 </div>
 
-<div class="league-grid">
-  <div class="material grid-item__league-manual">
-    <p class="league-grid__title">大会説明</p>
-    <mat-divider></mat-divider>
-    <p class="league-grid__contents--manual">{{ leagueManual }}</p>
-  </div>
-  <div class="grid-item__buttons">
-    <app-button [buttonText]="'Player登録'"></app-button>
-    <app-button [buttonText]="'成績登録'"></app-button>
-  </div>
-  <div class="material grid-item__league-admin-name">
-    <p class="league-grid__title">大会管理者</p>
-    <mat-divider></mat-divider>
-    <p class="league-grid__contents">{{ leagueAdminName }}</p>
-  </div>
-  <div class="material grid-item__league-total-game">
-    <p class="league-grid__title">総合対戦回数</p>
-    <mat-divider></mat-divider>
-    <p class="league-grid__contents">{{ leagueTotalGame }}</p>
-  </div>
-  <div class="material grid-item__league-date">
-    <p class="league-grid__title">大会期間</p>
-    <mat-divider></mat-divider>
-    <p class="league-grid__contents--date">
-      {{ leagueStartAt | date: 'yyyy/MM/dd HH:mm' }}
-    </p>
-    <p class="league-grid__contents--date">~</p>
-    <p class="league-grid__contents--date">
-      {{ leagueFnishAt | date: 'yyyy/MM/dd HH:mm' }}
-    </p>
-  </div>
-  <div class="material grid-item__table">
-    <app-table [columns]="tableColumns" [results]="tableData"></app-table>
-  </div>
+<div class="league">
+  <p class="league__title">大会期間</p>
+  <mat-divider></mat-divider>
+  <p class="league__content">
+    {{ leagueStartAt | date: 'yyyy/MM/dd HH:mm' }} ~
+    {{ leagueFnishAt | date: 'yyyy/MM/dd HH:mm' }}
+  </p>
+  <p class="league__title">大会説明</p>
+  <mat-divider></mat-divider>
+  <p class="league__content">{{ leagueManual }}</p>
+</div>
+<div class="material league-table">
+  <app-table [columns]="tableColumns" [results]="tableData"></app-table>
 </div>

--- a/src/app/pages/league-details/league-details.component.html
+++ b/src/app/pages/league-details/league-details.component.html
@@ -36,9 +36,4 @@
   <div class="material grid-item__table">
     <app-table [columns]="tableColumns" [results]="tableData"></app-table>
   </div>
-  <div class="material grid-item__rules">
-    <p class="league-grid__title">ルール</p>
-    <mat-divider></mat-divider>
-    <app-rules [rules]="rules"></app-rules>
-  </div>
 </div>

--- a/src/app/pages/league-details/league-details.component.html
+++ b/src/app/pages/league-details/league-details.component.html
@@ -12,6 +12,17 @@
   <p class="league__title">大会説明</p>
   <mat-divider></mat-divider>
   <p class="league__content">{{ leagueManual }}</p>
+
+  <div class="league-rules-toggle">
+    <p class="league__title">
+      ルール
+      <mat-slide-toggle (change)="isRules = isRules === false ? true : false"></mat-slide-toggle>
+    </p>
+    <mat-divider></mat-divider>
+    <ng-container *ngIf="isRules">
+      <app-rule-list [rules]="rules"></app-rule-list>
+    </ng-container>
+  </div>
 </div>
 <div class="material league-table">
   <app-table [columns]="tableColumns" [results]="tableData"></app-table>

--- a/src/app/pages/league-details/league-details.component.scss
+++ b/src/app/pages/league-details/league-details.component.scss
@@ -17,7 +17,7 @@
   width: 100%;
   gap: 1rem;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 10rem 10rem 10rem;
+  grid-template-rows: 10rem 10rem;
 
   p {
     margin: 0;
@@ -76,10 +76,5 @@
   &__table {
     grid-column: 1 / 4;
     grid-row: 3 / 4;
-  }
-
-  &__rules {
-    grid-column: 1 / 4;
-    grid-row: 4 / 5;
   }
 }

--- a/src/app/pages/league-details/league-details.component.scss
+++ b/src/app/pages/league-details/league-details.component.scss
@@ -7,74 +7,28 @@
 }
 
 .league-name {
+  display: flex;
+  justify-content: space-between;
   color: var.$titleFontColor;
   margin-top: 2rem;
   font-size: 2.5rem;
 }
 
-.league-grid {
-  display: grid;
-  width: 100%;
-  gap: 1rem;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 10rem 10rem;
-
-  p {
-    margin: 0;
-  }
-
+.league {
+  margin-top: 2rem;
   &__title {
+    color: var.$subTitleFontColor;
     font-size: 2rem;
-    text-align: center;
   }
-  &__contents {
-    font-size: 3rem;
-    text-align: center;
-    height: 8rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    &--manual {
-      font-size: 2rem;
-    }
-
-    &--date {
-      font-size: 2rem;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
+  &__content {
+    font-size: 1.5rem;
   }
+}
+
+.league-table {
+  margin-top: 4rem;
 }
 
 .material {
   @include material();
-}
-
-.grid-item {
-  &__league-manual {
-    grid-column: 1 / 3;
-    grid-row: 1 / 2;
-  }
-
-  &__league-admin-name {
-    grid-column: 1 / 2;
-    grid-row: 2 / 3;
-  }
-
-  &__league-total-game {
-    grid-column: 2 / 3;
-    grid-row: 2 / 3;
-  }
-
-  &__league-date {
-    grid-column: 3 / 4;
-    grid-row: 2 / 3;
-  }
-
-  &__table {
-    grid-column: 1 / 4;
-    grid-row: 3 / 4;
-  }
 }

--- a/src/app/pages/league-details/league-details.component.scss
+++ b/src/app/pages/league-details/league-details.component.scss
@@ -14,7 +14,16 @@
   font-size: 2.5rem;
 }
 
-.league {
+.league-buttons {
+  margin-top: 2rem;
+  display: flex;
+  gap: 0.5rem;
+  &__button {
+    width: 20rem;
+  }
+}
+
+.league-details {
   margin-top: 2rem;
   &__title {
     color: var.$subTitleFontColor;

--- a/src/app/pages/league-details/league-details.component.ts
+++ b/src/app/pages/league-details/league-details.component.ts
@@ -15,6 +15,7 @@ export class LeagueDetailsComponent implements OnInit {
   leagueFnishAt: Date = new Date();
   tableColumns: string[] = [];
   tableData: LeagueResult[] = [];
+  isRules = false;
   rules: Rules = {
     radioGame: '',
     radioDora: '',

--- a/src/app/pages/league-details/league-details.component.ts
+++ b/src/app/pages/league-details/league-details.component.ts
@@ -55,6 +55,30 @@ export class LeagueDetailsComponent implements OnInit {
         totalCalcPoint: 200.5,
         date: new Date('Sat Apr 30 2022 22:00:00 GMT+0900 (日本標準時)'),
       },
+      {
+        rank: '2位',
+        playerId: '02',
+        playerName: 'sample02',
+        totalGameCount: 34,
+        totalCalcPoint: 190.5,
+        date: new Date('Sat Apr 30 2022 22:00:00 GMT+0900 (日本標準時)'),
+      },
+      {
+        rank: '3位',
+        playerId: '03',
+        playerName: 'sample03',
+        totalGameCount: 34,
+        totalCalcPoint: -15,
+        date: new Date('Sat Apr 30 2022 22:00:00 GMT+0900 (日本標準時)'),
+      },
+      {
+        rank: '4位',
+        playerId: '04',
+        playerName: 'sample04',
+        totalGameCount: 34,
+        totalCalcPoint: -100,
+        date: new Date('Sat Apr 30 2022 22:00:00 GMT+0900 (日本標準時)'),
+      },
     ];
     this.rules = {
       radioGame: '2',

--- a/src/app/pages/league-details/league-details.component.ts
+++ b/src/app/pages/league-details/league-details.component.ts
@@ -7,6 +7,7 @@ import { LeagueResult } from '../../shared/interfaces/result';
   styleUrls: ['./league-details.component.scss'],
 })
 export class LeagueDetailsComponent implements OnInit {
+  leagueId = '';
   leagueName = '';
   leagueAdminName = '';
   leagueManual = '';
@@ -39,6 +40,7 @@ export class LeagueDetailsComponent implements OnInit {
   constructor() {}
 
   ngOnInit(): void {
+    this.leagueId = '01';
     this.leagueName = 'catBloomLeague';
     this.leagueAdminName = 'catBloom';
     this.leagueTotalGame = 200;


### PR DESCRIPTION
# Issue 
#54 
# 新規/変更内容
表示しない情報を削除
デザインの変更
ルールの表示をrules-listの表示に変更(トグルボタンで切り替え)
管理者用のボタンセットを表示
# 備考
Auth完成後に管理者用ボタンは表示を切り替える処理を追加する