### PR TITLE
#97 空欄時にサブミット禁止にする修正

### DIFF
--- a/src/app/pages/add-league/add-league.component.html
+++ b/src/app/pages/add-league/add-league.component.html
@@ -44,6 +44,14 @@
       <app-rules [rulesRadioValue]="formGroup.get('rulesRadio')?.value" (sendRules)="setRules($event)"></app-rules>
     </ng-container>
 
-    <button class="league__button" (click)="openDialog()" mat-stroked-button color="accent">大会登録</button>
+    <button
+      class="league__button"
+      mat-stroked-button
+      color="accent"
+      [disabled]="formGroup.invalid"
+      (click)="openDialog()"
+    >
+      大会登録
+    </button>
   </div>
 </form>

--- a/src/app/pages/add-player/add-player.component.html
+++ b/src/app/pages/add-player/add-player.component.html
@@ -6,7 +6,15 @@
       <mat-label>プレイヤー名</mat-label>
       <input matInput formControlName="playerName" [errorStateMatcher]="matcher" maxlength="20" />
     </mat-form-field>
-    <button class="add-player__button" mat-stroked-button color="accent" (click)="postPlayer()">追加</button>
+    <button
+      class="add-player__button"
+      mat-stroked-button
+      color="accent"
+      [disabled]="formGroup.invalid"
+      (click)="postPlayer()"
+    >
+      追加
+    </button>
   </div>
 </form>
 

--- a/src/app/pages/add-player/add-player.component.ts
+++ b/src/app/pages/add-player/add-player.component.ts
@@ -42,6 +42,9 @@ export class AddPlayerComponent implements OnInit, OnDestroy {
   }
 
   postPlayer() {
+    if (this.formGroup.invalid) {
+      return;
+    }
     const player: PlayerRequest = {
       leagueId: Number(this.activeRoute.snapshot.paramMap.get('league-id')),
       playerName: this.playerName.value,

--- a/src/app/pages/add-result/add-result.component.html
+++ b/src/app/pages/add-result/add-result.component.html
@@ -125,7 +125,9 @@
     </ng-container>
 
     <div class="result-buttons">
-      <button class="result-buttons__button" mat-stroked-button color="accent">登録</button>
+      <button class="result-buttons__button" [disabled]="formGroup.invalid" mat-stroked-button color="accent">
+        登録
+      </button>
       <button class="result-buttons__button" mat-stroked-button color="warn">リセット</button>
     </div>
   </div>


### PR DESCRIPTION
## Issue
#97 

## 新規/変更内容
validationError時にボタンを無効にする変更
データが空欄の際に、return処理を追加

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
