### PR TITLE
#99 Rulesのフォーム構成を変更

### DIFF
--- a/src/app/pages/add-league/add-league.component.html
+++ b/src/app/pages/add-league/add-league.component.html
@@ -28,20 +28,14 @@
     </mat-form-field>
     <div class="league__radio">
       <mat-radio-group formControlName="rulesRadio">
-        <mat-radio-button value="mahjongsoulRules">雀魂公式ルール</mat-radio-button>
-        <mat-radio-button value="tenhouRules">天鳳公式ルール</mat-radio-button>
+        <mat-radio-button value="mahjongsoulRules">雀魂半荘サンプル</mat-radio-button>
+        <mat-radio-button value="tenhouRules">天鳳半荘サンプル</mat-radio-button>
         <mat-radio-button value="custom">カスタムルール</mat-radio-button>
       </mat-radio-group>
     </div>
 
-    <ng-container *ngIf="formGroup.get('rulesRadio')?.value === 'mahjongsoulRules'">
-      <app-rules [rulesRadioValue]="formGroup.get('rulesRadio')?.value" (sendRules)="setRules($event)"></app-rules>
-    </ng-container>
-    <ng-container *ngIf="formGroup.get('rulesRadio')?.value === 'tenhouRules'">
-      <app-rules [rulesRadioValue]="formGroup.get('rulesRadio')?.value" (sendRules)="setRules($event)"></app-rules>
-    </ng-container>
-    <ng-container *ngIf="formGroup.get('rulesRadio')?.value === 'custom'">
-      <app-rules [rulesRadioValue]="formGroup.get('rulesRadio')?.value" (sendRules)="setRules($event)"></app-rules>
+    <ng-container *ngIf="rulesRadio.value">
+      <app-rules [formGroup]="formGroup"></app-rules>
     </ng-container>
 
     <button

--- a/src/app/pages/shared/components/rule-list/rule-list.component.html
+++ b/src/app/pages/shared/components/rule-list/rule-list.component.html
@@ -57,19 +57,19 @@
   <mat-label>ノーテン罰符</mat-label>
   <mat-list-item>
     <div class="rule-container">
-      <div>1人:{{ rules.inputPenalty1 }}/</div>
-      <div>2人:{{ rules.inputPenalty2 }}/</div>
-      <div>3人:{{ rules.inputPenalty3 }}</div>
+      <div>1人:{{ rules.inputPenalty1 }}</div>
+      <div>/2人:{{ rules.inputPenalty2 }}</div>
+      <div *ngIf="this.rules.radioGame === '1' || this.rules.radioGame === '2'">/3人:{{ rules.inputPenalty3 }}</div>
     </div>
   </mat-list-item>
   <mat-divider></mat-divider>
   <mat-label>ウマ</mat-label>
   <mat-list-item>
     <div class="rule-container">
-      <div>1位:{{ rules.inputUma1 }}/</div>
-      <div>2位:{{ rules.inputUma2 }}/</div>
-      <div>3位:{{ rules.inputUma3 }}/</div>
-      <div>4位:{{ rules.inputUma4 }}</div>
+      <div>1位:{{ rules.inputUma1 }}</div>
+      <div>/2位:{{ rules.inputUma2 }}</div>
+      <div>/3位:{{ rules.inputUma3 }}</div>
+      <div *ngIf="this.rules.radioGame === '1' || this.rules.radioGame === '2'">/4位:{{ rules.inputUma4 }}</div>
     </div>
   </mat-list-item>
   <mat-divider></mat-divider>

--- a/src/app/pages/shared/components/rules/rules.component.html
+++ b/src/app/pages/shared/components/rules/rules.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="formGroup" autocomplete="off" class="formGroup">
+<form [formGroup]="rulesGroup" autocomplete="off" class="formGroup">
   <div class="rules">
     <div class="rules__title">基本ルール</div>
     <mat-label>局数</mat-label>
@@ -88,7 +88,7 @@
           <mat-label>2人</mat-label>
           <input type="text" matInput formControlName="inputPenalty2" [appReplace]="inputPenalty2" />
         </mat-form-field>
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" *ngIf="radioGame.value === '1' || radioGame.value === '2'">
           <mat-label>3人</mat-label>
           <input type="text" matInput formControlName="inputPenalty3" [appReplace]="inputPenalty3" />
         </mat-form-field>
@@ -107,7 +107,7 @@
           <mat-label>3位</mat-label>
           <input type="text" matInput formControlName="inputUma3" [appReplace]="inputUma3" />
         </mat-form-field>
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" *ngIf="radioGame.value === '1' || radioGame.value === '2'">
           <mat-label>4位</mat-label>
           <input type="text" matInput formControlName="inputUma4" [appReplace]="inputUma4" />
         </mat-form-field>

--- a/src/app/pages/shared/components/rules/rules.component.ts
+++ b/src/app/pages/shared/components/rules/rules.component.ts
@@ -1,7 +1,9 @@
-import { Component, Input, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { Subscription } from 'rxjs';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { Rules } from '../../../../shared/interfaces/rules';
+import { MahjongSoulRules, TenhouRules } from '../../constants/const-rules';
 
 @Component({
   selector: 'app-rules',
@@ -9,144 +11,99 @@ import { Rules } from '../../../../shared/interfaces/rules';
   styleUrls: ['./rules.component.scss'],
 })
 export class RulesComponent implements OnInit, OnDestroy {
-  @Input() rules?: Rules;
-  @Input() rulesRadioValue?: string;
-  @Output() sendRules = new EventEmitter<Rules>();
-
+  @Input() formGroup!: FormGroup;
   // 雀魂公式ルール
-  readonly mahjongsoulRules: Rules = {
-    radioGame: '2',
-    radioDora: '2',
-    radioTanyao: '2',
-    radioTime: '3',
-    inputStartPoint: 25000,
-    inputFinishPoint: 30000,
-    inputReturnPoint: 25000,
-    inputCalledPoint: 0,
-    inputReachPoint: 1000,
-    inputDeposit: 300,
-    inputPenalty1: 1000,
-    inputPenalty2: 1500,
-    inputPenalty3: 3000,
-    inputUma1: 10,
-    inputUma2: 5,
-    inputUma3: -5,
-    inputUma4: -10,
-  };
+  mahjongsoulRules: Rules = MahjongSoulRules;
   // 天鳳公式ルール
-  readonly tenhouRules: Rules = {
-    radioGame: '2',
-    radioDora: '2',
-    radioTanyao: '2',
-    radioTime: '2',
-    inputStartPoint: 25000,
-    inputFinishPoint: 30000,
-    inputReturnPoint: 30000,
-    inputCalledPoint: 0,
-    inputReachPoint: 1000,
-    inputDeposit: 300,
-    inputPenalty1: 1000,
-    inputPenalty2: 1500,
-    inputPenalty3: 3000,
-    inputUma1: 20,
-    inputUma2: 10,
-    inputUma3: -10,
-    inputUma4: -20,
-  };
-  formGroup = new FormGroup({
-    radioGame: new FormControl('', [Validators.required]),
-    radioDora: new FormControl('', [Validators.required]),
-    radioTanyao: new FormControl('', [Validators.required]),
-    radioTime: new FormControl('', [Validators.required]),
-    inputStartPoint: new FormControl(25000, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputFinishPoint: new FormControl(30000, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputReturnPoint: new FormControl(25000, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputCalledPoint: new FormControl(0, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputReachPoint: new FormControl(1000, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputDeposit: new FormControl(300, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputPenalty1: new FormControl(1000, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputPenalty2: new FormControl(1500, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputPenalty3: new FormControl(3000, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputUma1: new FormControl(10, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputUma2: new FormControl(5, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputUma3: new FormControl(-5, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-    inputUma4: new FormControl(-10, [Validators.required, Validators.pattern(/^[\d-]+$/)]),
-  });
+  tenhouRules: Rules = TenhouRules;
+
+  get rulesGroup() {
+    return this.formGroup.get('rulesGroup') as FormGroup;
+  }
+  get rulesRadio() {
+    return this.formGroup.get('rulesRadio') as FormControl;
+  }
+  get radioGame() {
+    return this.rulesGroup.get('radioGame') as FormControl;
+  }
   get inputStartPoint() {
-    return this.formGroup.get('inputStartPoint') as FormControl;
+    return this.rulesGroup.get('inputStartPoint') as FormControl;
   }
   get inputFinishPoint() {
-    return this.formGroup.get('inputFinishPoint') as FormControl;
+    return this.rulesGroup.get('inputFinishPoint') as FormControl;
   }
   get inputReturnPoint() {
-    return this.formGroup.get('inputReturnPoint') as FormControl;
+    return this.rulesGroup.get('inputReturnPoint') as FormControl;
   }
   get inputCalledPoint() {
-    return this.formGroup.get('inputCalledPoint') as FormControl;
+    return this.rulesGroup.get('inputCalledPoint') as FormControl;
   }
   get inputReachPoint() {
-    return this.formGroup.get('inputReachPoint') as FormControl;
+    return this.rulesGroup.get('inputReachPoint') as FormControl;
   }
   get inputDeposit() {
-    return this.formGroup.get('inputDeposit') as FormControl;
+    return this.rulesGroup.get('inputDeposit') as FormControl;
   }
   get inputPenalty1() {
-    return this.formGroup.get('inputPenalty1') as FormControl;
+    return this.rulesGroup.get('inputPenalty1') as FormControl;
   }
   get inputPenalty2() {
-    return this.formGroup.get('inputPenalty2') as FormControl;
+    return this.rulesGroup.get('inputPenalty2') as FormControl;
   }
   get inputPenalty3() {
-    return this.formGroup.get('inputPenalty3') as FormControl;
+    return this.rulesGroup.get('inputPenalty3') as FormControl;
   }
   get inputUma1() {
-    return this.formGroup.get('inputUma1') as FormControl;
+    return this.rulesGroup.get('inputUma1') as FormControl;
   }
   get inputUma2() {
-    return this.formGroup.get('inputUma2') as FormControl;
+    return this.rulesGroup.get('inputUma2') as FormControl;
   }
   get inputUma3() {
-    return this.formGroup.get('inputUma3') as FormControl;
+    return this.rulesGroup.get('inputUma3') as FormControl;
   }
   get inputUma4() {
-    return this.formGroup.get('inputUma4') as FormControl;
+    return this.rulesGroup.get('inputUma4') as FormControl;
   }
+
   // 詳細ルール表示用のフォームコントロール
   isAdvanced = new FormControl(false);
-  private subscriptions = new Subscription();
+  private onDestroy$ = new Subject();
 
   constructor() {}
 
   ngOnInit(): void {
     this.setRules();
-    this.sendRules.emit(this.formGroup.value);
-    this.subscriptions = this.formGroup.valueChanges.subscribe(() => {
-      if (!this.formGroup.invalid) {
-        this.sendRules.emit(this.formGroup.value);
+    this.rulesRadio.valueChanges.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+      this.rulesGroup.reset();
+      this.setRules();
+    });
+    // 4人麻雀と3人麻雀で必須項目を切り替える
+    this.radioGame.valueChanges.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+      if (this.radioGame.value === '1' || this.radioGame.value === '2') {
+        this.inputPenalty3.setErrors({ require: true });
+        this.inputUma4.setErrors({ require: true });
+      } else if (this.radioGame.value === '3' || this.radioGame.value === '4') {
+        this.inputPenalty3.setErrors(null);
+        this.inputUma4.setErrors(null);
       }
     });
   }
 
   ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
+    this.onDestroy$.next();
   }
 
   // 固定ルールをセットする関数
   setRules() {
-    let rulesName: string;
-    if (this.rulesRadioValue) {
-      rulesName = this.rulesRadioValue;
+    if (this.rulesRadio.value !== 'custom') {
+      const rulesName = this.rulesRadio.value;
+      for (const control in this.rulesGroup.controls) {
+        this.rulesGroup.get(control)?.setValue((this as never)[rulesName][control]);
+      }
+      this.rulesGroup.disable();
     } else {
-      rulesName = 'rules';
-    }
-
-    if (rulesName && rulesName !== 'custom') {
-      for (const control in this.formGroup.controls) {
-        this.formGroup.get(control)?.setValue((this as never)[rulesName][control]);
-      }
-      if (!this.rules) {
-        this.formGroup.disable(); // 入力を無効化する
-      }
+      this.rulesGroup.enable();
     }
   }
 }

--- a/src/app/pages/shared/constants/const-rules.ts
+++ b/src/app/pages/shared/constants/const-rules.ts
@@ -1,0 +1,42 @@
+import { Rules } from '../../../shared/interfaces/rules';
+
+// 雀魂公式ルール
+export const MahjongSoulRules: Rules = {
+  radioGame: '2',
+  radioDora: '2',
+  radioTanyao: '1',
+  radioTime: '3',
+  inputStartPoint: 25000,
+  inputFinishPoint: 30000,
+  inputReturnPoint: 25000,
+  inputCalledPoint: 0,
+  inputReachPoint: 1000,
+  inputDeposit: 300,
+  inputPenalty1: 1000,
+  inputPenalty2: 1500,
+  inputPenalty3: 3000,
+  inputUma1: 10,
+  inputUma2: 5,
+  inputUma3: -5,
+  inputUma4: -10,
+};
+// 天鳳公式ルール
+export const TenhouRules: Rules = {
+  radioGame: '2',
+  radioDora: '2',
+  radioTanyao: '1',
+  radioTime: '2',
+  inputStartPoint: 25000,
+  inputFinishPoint: 30000,
+  inputReturnPoint: 30000,
+  inputCalledPoint: 0,
+  inputReachPoint: 1000,
+  inputDeposit: 300,
+  inputPenalty1: 1000,
+  inputPenalty2: 1500,
+  inputPenalty3: 3000,
+  inputUma1: 20,
+  inputUma2: 10,
+  inputUma3: -10,
+  inputUma4: -20,
+};


### PR DESCRIPTION
## Issue
#94 #99 

## 新規/変更内容
固定ルールを分離
validationをadd-leagueで行うため、rulesのformをadd-leagueに依存するように変更
３人麻雀用の処理を追加

## タスク
- [ ] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [ ] いいえ
