### PR TITLE
#87 playerDetailsのデザインを変更

### DIFF
--- a/src/app/pages/player-details/player-details.component.html
+++ b/src/app/pages/player-details/player-details.component.html
@@ -2,23 +2,28 @@
   <h2>{{ player.playerName }}</h2>
 
   <div class="player-grid">
-    <div class="material grid-item__total-game">
+    <div class="material player-grid__total-game">
       <p class="player-grid__title">対戦回数</p>
       <mat-divider></mat-divider>
       <p class="player-grid__contents">{{ player.playerGameCount }}</p>
     </div>
-    <div class="material grid-item__total-point">
+    <div class="material player-grid__total-point">
       <p class="player-grid__title">合計得点</p>
       <mat-divider></mat-divider>
       <p class="player-grid__contents">{{ player.playerCalcPoint }}</p>
     </div>
-    <div class="material grid-item__line">
+    <div class="material player-grid__total-average">
+      <p class="player-grid__title">平均着順</p>
+      <mat-divider></mat-divider>
+      <p class="player-grid__contents">{{ player.playerAverage }}</p>
+    </div>
+    <div class="material player-grid__line">
       <app-line-chart *ngIf="lineData$ | async as lineData" [lineData]="lineData"></app-line-chart>
     </div>
-    <div class="material grid-item__pie">
+    <div class="material player-grid__pie">
       <app-pie-chart *ngIf="pieData$ | async as pieData" [pieData]="pieData"></app-pie-chart>
     </div>
-    <div class="material grid-item__table">
+    <div class="material player-grid__table">
       <app-table
         *ngIf="playerResult$ | async as playerResult"
         [columns]="tableColumns"

--- a/src/app/pages/player-details/player-details.component.scss
+++ b/src/app/pages/player-details/player-details.component.scss
@@ -13,31 +13,19 @@ h2 {
 
 .player-grid {
   display: grid;
-  width: 100%;
   gap: 1rem;
-  grid-template-columns: 30% 30% 40%;
-  grid-template-rows: 10rem 10rem 10rem;
-
+  grid-template-columns: 1fr 1fr 1fr;
   &__title {
-    font-size: 2rem;
-    text-align: center;
+    padding: 0 1rem;
     height: 1rem;
   }
   &__contents {
-    font-size: 3rem;
     text-align: center;
+    font-size: 2rem;
     height: 8rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    @include mixin.center;
   }
-}
 
-.material {
-  @include mixin.material;
-}
-
-.grid-item {
   &__total-game {
     grid-column: 1 / 2;
     grid-row: 1 / 2;
@@ -46,16 +34,43 @@ h2 {
     grid-column: 2 / 3;
     grid-row: 1 / 2;
   }
+  &__total-average {
+    grid-column: 3 / 4;
+    grid-row: 1 / 2;
+  }
   &__line {
-    grid-column: 1 / 3;
+    grid-column: 1 / 4;
     grid-row: 2 / 4;
   }
   &__pie {
-    grid-column: 3 / 4;
+    grid-column: 4 / 5;
     grid-row: 1 / 4;
+    width: 300px;
   }
   &__table {
-    grid-column: 1 / 4;
+    grid-column: 1 / 5;
     grid-row: 4 / 5;
+  }
+}
+
+.material {
+  @include mixin.material;
+}
+
+@media screen and (max-width: 1500px) {
+  .player-grid {
+    &__line {
+      grid-column: 1 / 4;
+      grid-row: 2 / 4;
+    }
+    &__pie {
+      grid-column: 1 / 4;
+      grid-row: 4 / 5;
+      width: 100%;
+    }
+    &__table {
+      grid-column: 1 / 4;
+      grid-row: 5 / 6;
+    }
   }
 }

--- a/src/app/pages/player-details/player-details.component.scss
+++ b/src/app/pages/player-details/player-details.component.scss
@@ -61,16 +61,16 @@ h2 {
   .player-grid {
     &__line {
       grid-column: 1 / 4;
-      grid-row: 2 / 4;
+      grid-row: 2 / 3;
     }
     &__pie {
       grid-column: 1 / 4;
-      grid-row: 4 / 5;
+      grid-row: 3 / 4;
       width: 100%;
     }
     &__table {
       grid-column: 1 / 4;
-      grid-row: 5 / 6;
+      grid-row: 4 / 5;
     }
   }
 }

--- a/src/app/pages/shared/components/pie-chart/pie-chart.component.html
+++ b/src/app/pages/shared/components/pie-chart/pie-chart.component.html
@@ -1,4 +1,12 @@
 <div class="chart">
-  <canvas baseChart [type]="'pie'" [data]="pieChartData" [options]="pieChartOptions" [plugins]="pieChartPlugins">
+  <canvas
+    baseChart
+    width="200"
+    height="300"
+    [type]="'pie'"
+    [data]="pieChartData"
+    [options]="pieChartOptions"
+    [plugins]="pieChartPlugins"
+  >
   </canvas>
 </div>

--- a/src/app/pages/shared/components/table/table-result-row/table-result-row.component.html
+++ b/src/app/pages/shared/components/table/table-result-row/table-result-row.component.html
@@ -1,32 +1,28 @@
 <div class="result-container">
   <div class="result-container__item">
     <a routerLink="/player/{{ result.resultData[0].leagueId }}/{{ result.resultData[0].playerId }}">
-      <span>1位:</span>{{ result.resultData[0].playerName }}/{{ result.resultData[0].point }}/{{
-        result.resultData[0].calcPoint
-      }}</a
-    >
+      <span class="result-container__item--name">1位:{{ result.resultData[0].playerName }}</span>
+      <span>【{{ result.resultData[0].point }},{{ result.resultData[0].calcPoint }}】</span>
+    </a>
   </div>
   <div class="result-container__item">
     <a routerLink="/player/{{ result.resultData[1].leagueId }}/{{ result.resultData[1].playerId }}">
-      <span>2位:</span>{{ result.resultData[1].playerName }}/{{ result.resultData[1].point }}/{{
-        result.resultData[1].calcPoint
-      }}</a
-    >
+      <span class="result-container__item--name">2位:{{ result.resultData[1].playerName }}</span>
+      <span>【{{ result.resultData[1].point }},{{ result.resultData[1].calcPoint }}】</span>
+    </a>
   </div>
 </div>
 <div class="result-container">
   <div class="result-container__item">
     <a routerLink="/player/{{ result.resultData[2].leagueId }}/{{ result.resultData[2].playerId }}">
-      <span>3位:</span>{{ result.resultData[2].playerName }}/{{ result.resultData[2].point }}/{{
-        result.resultData[2].calcPoint
-      }}</a
-    >
+      <span class="result-container__item--name">3位:{{ result.resultData[2].playerName }}</span>
+      <span>【{{ result.resultData[2].point }},{{ result.resultData[2].calcPoint }}】</span>
+    </a>
   </div>
   <div class="result-container__item">
     <a routerLink="/player/{{ result.resultData[3].leagueId }}/{{ result.resultData[3].playerId }}">
-      <span>4位:</span>{{ result.resultData[3].playerName }}/{{ result.resultData[3].point }}/{{
-        result.resultData[3].calcPoint
-      }}</a
-    >
+      <span class="result-container__item--name">4位:{{ result.resultData[3].playerName }}</span
+      ><span>【{{ result.resultData[3].point }},{{ result.resultData[3].calcPoint }}】</span>
+    </a>
   </div>
 </div>

--- a/src/app/pages/shared/components/table/table-result-row/table-result-row.component.scss
+++ b/src/app/pages/shared/components/table/table-result-row/table-result-row.component.scss
@@ -3,9 +3,14 @@
 .result-container {
   display: flex;
   flex-wrap: wrap;
+  font-size: 1.5rem;
   &__item {
-    width: 50%;
-    min-width: 20rem;
+    padding: 0.5rem 0;
+    flex: 1;
+    &--name {
+      min-width: 14rem;
+      display: inline-flex;
+    }
     a {
       color: var.$normalFontColor;
       text-decoration: none;

--- a/src/app/shared/api/mock-web-api.service.ts
+++ b/src/app/shared/api/mock-web-api.service.ts
@@ -76,6 +76,7 @@ export class MockWebApiService implements InMemoryDbService {
           playerName: 'catBloom',
           playerGameCount: 34,
           playerCalcPoint: 200.5,
+          playerAverage: 2.3,
         },
         {
           id: 2,
@@ -83,6 +84,7 @@ export class MockWebApiService implements InMemoryDbService {
           playerName: 'player2',
           playerGameCount: 34,
           playerCalcPoint: 190.5,
+          playerAverage: 2.4,
         },
         {
           id: 3,
@@ -90,6 +92,7 @@ export class MockWebApiService implements InMemoryDbService {
           playerName: 'player3',
           playerGameCount: 34,
           playerCalcPoint: -15,
+          playerAverage: 2.6,
         },
         {
           id: 4,
@@ -97,6 +100,7 @@ export class MockWebApiService implements InMemoryDbService {
           playerName: 'player4',
           playerGameCount: 34,
           playerCalcPoint: -15,
+          playerAverage: 2.7,
         },
       ],
       result: [

--- a/src/app/shared/interfaces/player.ts
+++ b/src/app/shared/interfaces/player.ts
@@ -7,4 +7,5 @@ export interface PlayerResponse extends PlayerRequest {
   id: number;
   playerGameCount?: number;
   playerCalcPoint?: number;
+  playerAverage?: number;
 }


### PR DESCRIPTION
## Issue
#87

## 新規/変更内容
playerDetailsのデザインを変更
chartのサイズを固定化
result用のテーブルの表示崩れを修正
mediaqueryで1500px以下の表示を指定

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
