### PR TITLE
#128 headerにmenuButtonを設置

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { TableResultRowComponent } from './pages/shared/components/table/table-r
 import { TopComponent } from './pages/top/top.component';
 import { LoginComponent } from './pages/login/login.component';
 import { SignupComponent } from './pages/signup/signup.component';
+import { MenuListComponent } from './shared/components/menu-list/menu-list.component';
 
 // service
 import { MockWebApiService } from './shared/api/mock-web-api.service';
@@ -81,6 +82,7 @@ import { provideAuth, getAuth } from '@angular/fire/auth';
     TopComponent,
     LoginComponent,
     SignupComponent,
+    MenuListComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -1,7 +1,14 @@
 <mat-toolbar color="primary">
-  <a class="header-title" routerLink="/"> TitleLogo</a>
+  <a class="header-title" routerLink="/">TitleLogo</a>
   <span class="spacer"></span>
-  <button class="header-session-button" *ngIf="(user$ | async) === null" routerLink="/login">ログイン</button>
-  <button class="header-session-button" *ngIf="user$ | async" (click)="logout()">ログアウト</button>
-  <button class="header-session-button" routerLink="/signup">アカウント作成</button>
+  <ng-template #elseUser>
+    <button class="header-session-button" mat-button routerLink="/signup">アカウント作成</button>
+    <button class="header-session-button" mat-button routerLink="/login">ログイン</button>
+  </ng-template>
+  <button *ngIf="user$ | async as user; else elseUser" mat-icon-button [matMenuTriggerFor]="menu">
+    <mat-icon>account_circle</mat-icon>
+    <mat-menu #menu="matMenu">
+      <app-menu-list [userName]="user.displayName"></app-menu-list>
+    </mat-menu>
+  </button>
 </mat-toolbar>

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -1,5 +1,6 @@
 @use 'variable' as var;
 @use '@angular/material' as mat;
+@use 'mixin' as mixin;
 
 .spacer {
   flex: 1 1 auto;
@@ -18,12 +19,6 @@
 }
 
 .header-session-button {
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  color: var.$deepFontColor;
-  height: 100%;
-  font-size: 1.5rem;
   &:hover {
     background-color: darken(var.$primary, 10%);
   }

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -12,8 +12,4 @@ export class HeaderComponent implements OnInit {
   constructor(private authService: AuthService) {}
 
   ngOnInit(): void {}
-
-  logout() {
-    this.authService.logout();
-  }
 }

--- a/src/app/shared/components/menu-list/menu-list.component.html
+++ b/src/app/shared/components/menu-list/menu-list.component.html
@@ -1,0 +1,7 @@
+<div class="menu-list">
+  <mat-label>{{ userName }}</mat-label>
+  <mat-divider></mat-divider>
+  <button mat-menu-item routerLink="/league"><mat-icon>home</mat-icon>MyLeague</button>
+  <button mat-menu-item routerLink=""><mat-icon>settings</mat-icon>設定</button>
+  <button mat-menu-item (click)="logout()"><mat-icon>logout</mat-icon>ログアウト</button>
+</div>

--- a/src/app/shared/components/menu-list/menu-list.component.scss
+++ b/src/app/shared/components/menu-list/menu-list.component.scss
@@ -1,0 +1,10 @@
+@use 'variable' as var;
+@use 'mixin' as mixin;
+
+.menu-list {
+  mat-label {
+    @include mixin.center;
+    padding-bottom: 1rem;
+    color: var.$primary;
+  }
+}

--- a/src/app/shared/components/menu-list/menu-list.component.spec.ts
+++ b/src/app/shared/components/menu-list/menu-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MenuListComponent } from './menu-list.component';
+
+describe('MenuListComponent', () => {
+  let component: MenuListComponent;
+  let fixture: ComponentFixture<MenuListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MenuListComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MenuListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/menu-list/menu-list.component.ts
+++ b/src/app/shared/components/menu-list/menu-list.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { AuthService } from '../../auth/auth.service';
+
+@Component({
+  selector: 'app-menu-list',
+  templateUrl: './menu-list.component.html',
+  styleUrls: ['./menu-list.component.scss'],
+})
+export class MenuListComponent implements OnInit {
+  @Input() userName!: string | null;
+
+  constructor(private authService: AuthService) {}
+
+  ngOnInit(): void {}
+
+  logout() {
+    this.authService.logout();
+  }
+}


### PR DESCRIPTION
## Issue
#128 

## 新規/変更内容
menu-listコンポーネントを作成
認証が通っている際にメニューを表示するボタンを設置

## タスク
- [ ] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [ ] いいえ
