### PR TITLE
#132 border-styleの崩れを修正 

### DIFF
--- a/src/app/pages/shared/components/player-list/player-list-edit/player-list-edit.component.scss
+++ b/src/app/pages/shared/components/player-list/player-list-edit/player-list-edit.component.scss
@@ -24,6 +24,7 @@
       outline: none;
       border: none;
       border-bottom: solid 1px var.$accent;
+      border-radius: 0;
       -webkit-appearance: none;
       -moz-appearance: none;
       appearance: none;


### PR DESCRIPTION
## Issue
#132

## 新規/変更内容
モバイル端末でplayer-list-editでeditを選択するとborder-radiusが残るため
border-radius: 0;を設置

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
