### PR TITLE
#135 ノーテン罰符とウマの表示崩れを修正 

### DIFF
--- a/src/app/pages/shared/components/rule-list/rule-list.component.html
+++ b/src/app/pages/shared/components/rule-list/rule-list.component.html
@@ -57,19 +57,19 @@
   <mat-label>ノーテン罰符</mat-label>
   <mat-list-item>
     <div class="rule-container">
-      <div>1人:{{ rules.inputPenalty1 }}</div>
-      <div>/2人:{{ rules.inputPenalty2 }}</div>
-      <div *ngIf="this.rules.radioGame === '1' || this.rules.radioGame === '2'">/3人:{{ rules.inputPenalty3 }}</div>
+      <div>1人【{{ rules.inputPenalty1 }}】</div>
+      <div>2人【{{ rules.inputPenalty2 }}】</div>
+      <div *ngIf="this.rules.radioGame === '1' || this.rules.radioGame === '2'">3人【{{ rules.inputPenalty3 }}】</div>
     </div>
   </mat-list-item>
   <mat-divider></mat-divider>
   <mat-label>ウマ</mat-label>
   <mat-list-item>
     <div class="rule-container">
-      <div>1位:{{ rules.inputUma1 }}</div>
-      <div>/2位:{{ rules.inputUma2 }}</div>
-      <div>/3位:{{ rules.inputUma3 }}</div>
-      <div *ngIf="this.rules.radioGame === '1' || this.rules.radioGame === '2'">/4位:{{ rules.inputUma4 }}</div>
+      <div>1位【{{ rules.inputUma1 }}】</div>
+      <div>2位【{{ rules.inputUma2 }}】</div>
+      <div>3位【{{ rules.inputUma3 }}】</div>
+      <div *ngIf="this.rules.radioGame === '1' || this.rules.radioGame === '2'">4位【{{ rules.inputUma4 }}】</div>
     </div>
   </mat-list-item>
   <mat-divider></mat-divider>


### PR DESCRIPTION
## Issue
#135

## 新規/変更内容
モバイル端末でダイアログのノーテン罰符とウマの表示が崩れるため
デザインを変更することで対応

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
