### PR TITLE
#144 リーグ登録時のuidをtokenで受け取るように変更

### DIFF
--- a/src/app/pages/add-league/add-league.component.ts
+++ b/src/app/pages/add-league/add-league.component.ts
@@ -10,7 +10,6 @@ import { takeUntil } from 'rxjs/operators';
 import { DatePipe } from '@angular/common';
 import { MyErrorStateMatcher } from 'src/app/shared/utils/error-state-matcher';
 import { MahjongSoulRules, TenhouRules, MLeagueRules } from '../shared/constants/const-rules';
-import { AuthService } from 'src/app/shared/auth/auth.service';
 
 @Component({
   selector: 'app-add-league',
@@ -66,18 +65,10 @@ export class AddLeagueComponent implements OnInit, OnDestroy {
   get gameType() {
     return this.rulesGroup.get('gameType') as FormControl;
   }
-
-  user$ = this.auth.user;
   matcher = new MyErrorStateMatcher();
-  private uid = '';
   private onDestroy$ = new Subject();
 
-  constructor(
-    private leagueService: LeagueService,
-    private auth: AuthService,
-    private matDialog: MatDialog,
-    private datePipe: DatePipe
-  ) {}
+  constructor(private leagueService: LeagueService, private matDialog: MatDialog, private datePipe: DatePipe) {}
 
   ngOnInit(): void {
     // 日付整形用
@@ -90,13 +81,6 @@ export class AddLeagueComponent implements OnInit, OnDestroy {
     // rulesRadio変更時の処理
     this.rulesRadio.valueChanges.pipe(takeUntil(this.onDestroy$)).subscribe((rulesRadioValue) => {
       this.setRules(rulesRadioValue);
-    });
-
-    this.user$.pipe(takeUntil(this.onDestroy$)).subscribe((user) => {
-      if (!user) {
-        return;
-      }
-      this.uid = user.uid;
     });
   }
 
@@ -173,7 +157,6 @@ export class AddLeagueComponent implements OnInit, OnDestroy {
       manual: this.manual.value.trim(),
       startAt: !this.date.value[0] ? '' : this.date.value[0],
       finishAt: !this.date.value[1] ? '' : this.date.value[1],
-      uid: this.uid,
       rules: newRules,
     };
     this.leagueService.postLeague(newleague);

--- a/src/app/shared/interfaces/league.ts
+++ b/src/app/shared/interfaces/league.ts
@@ -6,11 +6,14 @@ export interface LeagueRequest {
   manual?: string;
   startAt?: string;
   finishAt?: string;
-  uid: string;
   rules: Rules;
 }
 export interface LeagueResponse extends LeagueRequest {
   id: string;
+  uids?: {
+    uid: string;
+    leagueId: string;
+  }[];
 }
 export interface LeagueDialog {
   name: string;


### PR DESCRIPTION
## Issue
#144

## 新規/変更内容
API側でtokenから取得するため
uidをpostデータに含む処理を削除

## 備考
optional

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
