### PR TITLE
#141 リーグサーチ用のコンポーネントを作成

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { TopComponent } from './pages/top/top.component';
 import { LoginComponent } from './pages/login/login.component';
 import { SignupComponent } from './pages/signup/signup.component';
 import { MenuListComponent } from './shared/components/menu-list/menu-list.component';
+import { SearchComponent } from './shared/components/search/search.component';
 
 // service
 // import { MockWebApiService } from './shared/api/mock-web-api.service';
@@ -86,6 +87,7 @@ import { provideAuth, getAuth } from '@angular/fire/auth';
     SignupComponent,
     MenuListComponent,
     CustomSlicePipe,
+    SearchComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/pages/top/top.component.html
+++ b/src/app/pages/top/top.component.html
@@ -1,2 +1,12 @@
 <button mat-button color="primary" routerLink="/login">ログイン</button>
 <button mat-button color="primary" routerLink="/signup">新規登録</button>
+
+<app-search [auto]="auto" (sendValue)="leagueSearch($event)"></app-search>
+<!--Todo オートコンプリートのコンポーネントを分離する -->
+<mat-autocomplete #auto="matAutocomplete">
+  <ng-container *ngIf="search$ | async as league">
+    <mat-option *ngFor="let l of league" routerLink="/league/{{ l.id }}">
+      {{ l.name }}
+    </mat-option>
+  </ng-container>
+</mat-autocomplete>

--- a/src/app/pages/top/top.component.ts
+++ b/src/app/pages/top/top.component.ts
@@ -1,4 +1,5 @@
 import { OnInit, Component } from '@angular/core';
+import { LeagueService } from 'src/app/shared/services/league.service';
 
 @Component({
   selector: 'app-top',
@@ -6,7 +7,12 @@ import { OnInit, Component } from '@angular/core';
   styleUrls: ['./top.component.scss'],
 })
 export class TopComponent implements OnInit {
-  constructor() {}
+  search$ = this.leagueService.leagueSearchSubject$;
+  constructor(private leagueService: LeagueService) {}
 
   ngOnInit(): void {}
+
+  leagueSearch(value: string) {
+    this.leagueService.searchLeague(value);
+  }
 }

--- a/src/app/shared/components/search/search.component.html
+++ b/src/app/shared/components/search/search.component.html
@@ -1,0 +1,6 @@
+<form class="search">
+  <mat-form-field class="search-input" appearance="outline">
+    <mat-icon matPrefix>search &nbsp;</mat-icon>
+    <input matInput type="text" [formControl]="search" [matAutocomplete]="this.auto" />
+  </mat-form-field>
+</form>

--- a/src/app/shared/components/search/search.component.scss
+++ b/src/app/shared/components/search/search.component.scss
@@ -1,0 +1,6 @@
+.search-input {
+  width: 100%;
+  mat-icon {
+    padding-right: 0.5rem;
+  }
+}

--- a/src/app/shared/components/search/search.component.spec.ts
+++ b/src/app/shared/components/search/search.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SearchComponent } from './search.component';
+
+describe('SearchComponent', () => {
+  let component: SearchComponent;
+  let fixture: ComponentFixture<SearchComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SearchComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/search/search.component.spec.ts
+++ b/src/app/shared/components/search/search.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SearchComponent } from './search.component';
 
 describe('SearchComponent', () => {
@@ -20,5 +19,12 @@ describe('SearchComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('@Output test', () => {
+    component.search.setValue('test');
+    component.sendValue.subscribe((value) => {
+      expect(value).toBe('test');
+    });
   });
 });

--- a/src/app/shared/components/search/search.component.ts
+++ b/src/app/shared/components/search/search.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-search',
+  templateUrl: './search.component.html',
+  styleUrls: ['./search.component.scss'],
+})
+export class SearchComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/shared/components/search/search.component.ts
+++ b/src/app/shared/components/search/search.component.ts
@@ -1,12 +1,42 @@
-import { Component, OnInit } from '@angular/core';
+import { OnInit, Component, OnDestroy, Output, EventEmitter, Input } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatAutocomplete } from '@angular/material/autocomplete';
+import { of, Subject } from 'rxjs';
+import { takeUntil, debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-search',
   templateUrl: './search.component.html',
   styleUrls: ['./search.component.scss'],
 })
-export class SearchComponent implements OnInit {
+export class SearchComponent implements OnInit, OnDestroy {
+  @Input() auto!: MatAutocomplete;
+  @Output() sendValue = new EventEmitter<string>();
+
+  search: FormControl = new FormControl('');
+  private onDestroy$ = new Subject();
+
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.search.valueChanges
+      .pipe(
+        takeUntil(this.onDestroy$),
+        debounceTime(500),
+        distinctUntilChanged((pre, cur) => {
+          //空白をトリミングして判定 同値はoutputしない
+          return String(pre).trim() === String(cur).trim();
+        }),
+        switchMap((value) => {
+          return of(value);
+        })
+      )
+      .subscribe((value: string) => {
+        this.sendValue.emit(value);
+      });
+  }
+
+  ngOnDestroy() {
+    this.onDestroy$.next();
+  }
 }


### PR DESCRIPTION
## Issue
#141

## 新規/変更内容
searchコンポーネントを作成
mat-autocompleteで検索結果を表示
各leagueページにアクセスできるようにする
topに仮設置

## 備考
#150 autocompleteのコンポーネントに分離する方法がわからないため直書き

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
