### PR TITLE
#152 初期取得のリーグリストをtokenから取得に変更

### DIFF
--- a/src/app/pages/admin-my-league/admin-my-league.component.ts
+++ b/src/app/pages/admin-my-league/admin-my-league.component.ts
@@ -19,13 +19,7 @@ export class AdminMyLeagueComponent implements OnInit, OnDestroy {
   constructor(private leagueService: LeagueService, private auth: AuthService) {}
 
   ngOnInit(): void {
-    this.user$.pipe(distinctUntilChanged(), takeUntil(this.onDestroy$)).subscribe((user) => {
-      if (!user) {
-        return;
-      } else {
-        this.leagueService.getLeagueList(user.uid);
-      }
-    });
+    this.leagueService.getLeagueList();
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/services/league.service.ts
+++ b/src/app/shared/services/league.service.ts
@@ -43,14 +43,19 @@ export class LeagueService {
       });
   }
 
-  //大会リストを取得
-  getLeagueList(uid: string): void {
+  //tokenから大会リストを取得
+  getLeagueList(): void {
     this.http
-      .get<LeagueResponse[]>(`${this.apiUrl}/list/${uid}`)
+      .get<LeagueResponse[]>(`${this.apiUrl}/list`)
       .pipe()
-      .subscribe((res) => {
-        this.leagueListSubject.next(res);
-      });
+      .subscribe(
+        (res) => {
+          this.leagueListSubject.next(res);
+        },
+        () => {
+          this.leagueListSubject.next([]);
+        }
+      );
   }
 
   //大会の取得


### PR DESCRIPTION
## Issue
#152

## 新規/変更内容
componentでuidを取得せず、API通信時のtokenからリストを取得する

## タスク
- [ ] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [ ] いいえ
