### PR TITLE
#152 初期取得のリーグリストをtokenから取得に変更

### DIFF
--- a/src/app/pages/admin-my-league/admin-my-league.component.ts
+++ b/src/app/pages/admin-my-league/admin-my-league.component.ts
@@ -1,8 +1,5 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { faFileCirclePlus } from '@fortawesome/free-solid-svg-icons';
-import { Subject } from 'rxjs';
-import { takeUntil, distinctUntilChanged } from 'rxjs/operators';
-import { AuthService } from 'src/app/shared/auth/auth.service';
 import { LeagueService } from 'src/app/shared/services/league.service';
 
 @Component({
@@ -10,25 +7,12 @@ import { LeagueService } from 'src/app/shared/services/league.service';
   templateUrl: './admin-my-league.component.html',
   styleUrls: ['./admin-my-league.component.scss'],
 })
-export class AdminMyLeagueComponent implements OnInit, OnDestroy {
+export class AdminMyLeagueComponent implements OnInit {
   iconFileCirclePlus = faFileCirclePlus;
   leagueList$ = this.leagueService.leagueList$;
-  user$ = this.auth.user;
-  private onDestroy$ = new Subject();
-
-  constructor(private leagueService: LeagueService, private auth: AuthService) {}
+  constructor(private leagueService: LeagueService) {}
 
   ngOnInit(): void {
-    this.user$.pipe(distinctUntilChanged(), takeUntil(this.onDestroy$)).subscribe((user) => {
-      if (!user) {
-        return;
-      } else {
-        this.leagueService.getLeagueList(user.uid);
-      }
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.onDestroy$.next();
+    this.leagueService.getLeagueList();
   }
 }

--- a/src/app/shared/services/league.service.ts
+++ b/src/app/shared/services/league.service.ts
@@ -43,14 +43,19 @@ export class LeagueService {
       });
   }
 
-  //大会リストを取得
-  getLeagueList(uid: string): void {
+  //tokenから大会リストを取得
+  getLeagueList(): void {
     this.http
-      .get<LeagueResponse[]>(`${this.apiUrl}/list/${uid}`)
+      .get<LeagueResponse[]>(`${this.apiUrl}/list`)
       .pipe()
-      .subscribe((res) => {
-        this.leagueListSubject.next(res);
-      });
+      .subscribe(
+        (res) => {
+          this.leagueListSubject.next(res);
+        },
+        () => {
+          this.leagueListSubject.next([]);
+        }
+      );
   }
 
   //大会の取得


### PR DESCRIPTION
## Issue
#152

## 新規/変更内容
componentでuidを取得せず、API通信時のtokenからリストを取得する

## 備考
修正後のプルリク

## タスク
- [ ] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [ ] いいえ
