### PR TITLE
#158 3人麻雀のデータが表示できない 

### DIFF
--- a/src/app/pages/shared/components/table/table-result-row/table-result-row.component.html
+++ b/src/app/pages/shared/components/table/table-result-row/table-result-row.component.html
@@ -25,7 +25,7 @@
       <span>【{{ result.results[2].point }},{{ result.results[2].calcPoint }}】</span>
     </a>
   </div>
-  <div class="result-container__item">
+  <div class="result-container__item" *ngIf="result.results[3]">
     <a routerLink="/player/{{ result.leagueId }}/{{ result.results[3].playerId }}">
       <span class="result-container__item--name"
         >{{ result.results[3].rank }}位:{{ result.results[3].playerName | customSlice: 10 }}


### PR DESCRIPTION
## Issue
#158

## 新規/変更内容
3人麻雀のデータ表示時、エラーが発生
データがないときは表示しないことで対応

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
