### PR TITLE
否定語読み正規表現を使用するとブラウザがクラッシュする

### DIFF
--- a/src/app/shared/directives/replace.directive.spec.ts
+++ b/src/app/shared/directives/replace.directive.spec.ts
@@ -44,7 +44,15 @@ describe('ReplaceDirective', () => {
     expect(input.value).toEqual('102');
   });
 
-  it('Remove initial - except -', () => {
+  it('Remove initial - except - no.1', () => {
+    const input = de.nativeElement as HTMLInputElement;
+    input.value = '12-34--5';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(input.value).toEqual('12345');
+  });
+
+  it('Remove initial - except - no.2', () => {
     const input = de.nativeElement as HTMLInputElement;
     input.value = '--12-34--5';
     input.dispatchEvent(new Event('input'));

--- a/src/app/shared/directives/replace.directive.ts
+++ b/src/app/shared/directives/replace.directive.ts
@@ -17,7 +17,12 @@ export class ReplaceDirective implements OnInit {
     //数字とハイフン以外の文字を除去
     newValue = newValue.replace(/[^\d-]/g, '');
     //先頭以外の-を除去
-    newValue = newValue.replace(/(?<!^)-/g, '');
+    if (newValue.slice(0, 1) === '-') {
+      newValue = newValue.replace(/-/g, '');
+      newValue = '-' + newValue;
+    } else {
+      newValue = newValue.replace(/-/g, '');
+    }
     //先頭が-直後の0を除去
     newValue = newValue.replace(/^(-)0+/g, '$1');
     //先頭が0で2桁以上の数字は先頭の0を除去


### PR DESCRIPTION
## Issue
#156
## 新規/変更内容
否定語読み正規表現の利用を断念  
ifで分岐するように変更

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
