### PR TITLE
ハイフン要素を半角ハイフンに変換

### DIFF
--- a/src/app/shared/directives/replace.directive.spec.ts
+++ b/src/app/shared/directives/replace.directive.spec.ts
@@ -20,12 +20,20 @@ describe('ReplaceDirective', () => {
     de = fixture.debugElement.query(By.directive(ReplaceDirective));
   });
 
-  it('Convert full-width characters to half-width characters', () => {
+  it('Convert full-width numbers to half-width numbers', () => {
     const input = de.nativeElement as HTMLInputElement;
     input.value = '１２３４';
     input.dispatchEvent(new Event('input'));
     fixture.detectChanges();
     expect(input.value).toEqual('1234');
+  });
+
+  it('Convert hyphen characters to half-width hyphen', () => {
+    const input = de.nativeElement as HTMLInputElement;
+    input.value = '-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(input.value).toEqual('-');
   });
 
   it('Remove non number', () => {
@@ -44,7 +52,7 @@ describe('ReplaceDirective', () => {
     expect(input.value).toEqual('102');
   });
 
-  it('Remove initial - except - no.1', () => {
+  it('Remove hyphen except initial hyphen no.1', () => {
     const input = de.nativeElement as HTMLInputElement;
     input.value = '12-34--5';
     input.dispatchEvent(new Event('input'));
@@ -52,7 +60,7 @@ describe('ReplaceDirective', () => {
     expect(input.value).toEqual('12345');
   });
 
-  it('Remove initial - except - no.2', () => {
+  it('Remove hyphen except initial hyphen no.2', () => {
     const input = de.nativeElement as HTMLInputElement;
     input.value = '--12-34--5';
     input.dispatchEvent(new Event('input'));
@@ -60,7 +68,7 @@ describe('ReplaceDirective', () => {
     expect(input.value).toEqual('-12345');
   });
 
-  it('Remove initial - after 0 ', () => {
+  it('Remove 0 after initial hyphen', () => {
     const input = de.nativeElement as HTMLInputElement;
     input.value = '-0012345';
     input.dispatchEvent(new Event('input'));

--- a/src/app/shared/directives/replace.directive.ts
+++ b/src/app/shared/directives/replace.directive.ts
@@ -14,6 +14,8 @@ export class ReplaceDirective implements OnInit {
     newValue = newValue.replace(/[０-９]/g, (s) => {
       return String.fromCharCode(s.charCodeAt(0) - 0xfee0);
     });
+    //半角ハイフンに似た要素を半角ハイフンに変換
+    newValue = newValue.replace(/[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━]/g, '-');
     //数字とハイフン以外の文字を除去
     newValue = newValue.replace(/[^\d-]/g, '');
     //先頭以外の-を除去


### PR DESCRIPTION
## Issue
#162

## 新規/変更内容
ハイフン要素を半角ハイフンに変換する
replace directiveで対応

## 備考
テストの誤字を修正

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
