### PR TITLE
リーグ詳細のテーブルに平均着順を追加

### DIFF
--- a/src/app/pages/league-details/league-details.component.ts
+++ b/src/app/pages/league-details/league-details.component.ts
@@ -13,7 +13,7 @@ import { LeagueResultResponse } from 'src/app/shared/interfaces/result';
 export class LeagueDetailsComponent implements OnInit, OnDestroy {
   league$ = this.leagueService.league$;
   leagueResult$ = this.resultService.leagueResult$;
-  tableColumns: string[] = ['rank', 'name', 'totalGame', 'totalCalcPoint'];
+  tableColumns: string[] = ['rank', 'name', 'totalGame', 'totalCalcPoint', 'averageRank'];
   isRules = false;
   private onDestroy$ = new Subject<boolean>();
 

--- a/src/app/pages/shared/components/table/table-result-row/table-result-row.component.scss
+++ b/src/app/pages/shared/components/table/table-result-row/table-result-row.component.scss
@@ -6,7 +6,7 @@
     min-width: 7rem;
     flex: 1;
     &--name {
-      min-width: 7rem;
+      width: 10rem;
       display: inline-flex;
     }
     a {
@@ -17,4 +17,9 @@
       }
     }
   }
+}
+
+span {
+  width: 7rem;
+  display: inline-block;
 }

--- a/src/app/shared/interfaces/result.ts
+++ b/src/app/shared/interfaces/result.ts
@@ -7,6 +7,7 @@ export interface LeagueResultResponse {
   totalGame: number;
   totalPoint: number;
   calcTotalPoint: number;
+  averageRank: number;
   leagueId: string;
 }
 

--- a/src/app/shared/pipes/japanese.pipe.ts
+++ b/src/app/shared/pipes/japanese.pipe.ts
@@ -20,10 +20,12 @@ export class JapanesePipe implements PipeTransform {
         return (value = '登録日');
       case 'name':
         return (value = '名前');
+      case 'averageRank':
+        return (value = '平均着順');
       case 'totalGame':
         return (value = '対戦数');
       case 'totalCalcPoint':
-        return (value = '合計点');
+        return (value = '合計得点');
 
       default:
         return value;


### PR DESCRIPTION
## Issue
#179

## 新規/変更内容
league-detailsのテーブルに平均着順を追加
japanese-pipeに対応カラムの日本語訳を追加

## 備考
responsive用スタイルの微調整コミット含む

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
