### PR TITLE
http headerにLeagueIDを追加

### DIFF
--- a/src/app/shared/interceptor/token.interceptor.ts
+++ b/src/app/shared/interceptor/token.interceptor.ts
@@ -3,12 +3,13 @@ import { AuthService } from '../auth/auth.service';
 import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/common/http';
 import { from, Observable } from 'rxjs';
 import { switchMap, distinctUntilChanged } from 'rxjs/operators';
+import { LeagueService } from '../services/league.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class TokenInterceptor implements HttpInterceptor {
-  constructor(private authService: AuthService) {}
+  constructor(private authService: AuthService, private leagueService: LeagueService) {}
 
   //requestの際にtokenをheaderに追加
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
@@ -28,6 +29,7 @@ export class TokenInterceptor implements HttpInterceptor {
             setHeaders: {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${token}`,
+              LeagueID: this.leagueService.getLeagueIdByURL(),
             },
           });
           return next.handle(req);


### PR DESCRIPTION
## Issue
#189

## 新規/変更内容
LeagueIDを認証に使用する
URLからリーグIDを取得する関数を作成しヘッダーに追加する

## 備考
コメントの追加
軽度な修正とリファクタリング含む

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
