### PR TITLE
WARNING:The same density styles are generated multiple times.の修正

### DIFF
--- a/src/sass/_theme.scss
+++ b/src/sass/_theme.scss
@@ -46,5 +46,5 @@ $dark-theme: mat.define-dark-theme(
 @include mat.core($custom-typography);
 @include mat.all-component-themes($light-theme);
 .dark-theme {
-  @include mat.all-component-themes($dark-theme);
+  @include mat.all-component-colors($dark-theme);
 }


### PR DESCRIPTION
## Issue
#195

## 新規/変更内容
WARNING:The same density styles are generated multiple times.の修正
詳細:https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
