### PR TITLE
リーグ選択でプレイヤー、ゲームを登録できるようにする

### DIFF
--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AdminComponent } from './admin.component';
 import { MyLeagueComponent } from './my-league/my-league.component';
 import { LeagueComponent } from './league/league.component';
 import { PlayerComponent } from './player/player.component';
@@ -7,12 +8,18 @@ import { GameComponent } from './game/game.component';
 import { AuthGuard } from '../guard/auth.guard';
 
 const routes: Routes = [
-  { path: '', redirectTo: 'league', pathMatch: 'full' },
-  { path: 'league', component: MyLeagueComponent, canActivate: [AuthGuard] },
-  { path: 'league/add', component: LeagueComponent, canActivate: [AuthGuard] },
-  { path: 'player/edit/:league-id', component: PlayerComponent, canActivate: [AuthGuard] },
-  { path: 'game/edit/:league-id', component: GameComponent, canActivate: [AuthGuard] },
-  { path: 'game/edit/:league-id/:game-id', component: GameComponent, canActivate: [AuthGuard] },
+  {
+    path: '',
+    component: AdminComponent,
+    canActivate: [AuthGuard],
+    children: [
+      { path: 'league', component: MyLeagueComponent, canActivate: [AuthGuard] },
+      { path: 'league/add', component: LeagueComponent, canActivate: [AuthGuard] },
+      { path: 'player/edit', component: PlayerComponent, canActivate: [AuthGuard] },
+      { path: 'game/edit', component: GameComponent, canActivate: [AuthGuard] },
+      { path: 'game/edit/:game-id', component: GameComponent, canActivate: [AuthGuard] },
+    ],
+  },
 ];
 
 @NgModule({

--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -13,7 +13,7 @@ const routes: Routes = [
     component: AdminComponent,
     canActivate: [AuthGuard],
     children: [
-      { path: 'league', component: MyLeagueComponent, canActivate: [AuthGuard] },
+      { path: 'league/list', component: MyLeagueComponent, canActivate: [AuthGuard] },
       { path: 'league/add', component: LeagueComponent, canActivate: [AuthGuard] },
       { path: 'player/edit', component: PlayerComponent, canActivate: [AuthGuard] },
       { path: 'game/edit', component: GameComponent, canActivate: [AuthGuard] },

--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -6,7 +6,6 @@
     #rla="routerLinkActive"
     [active]="rla.isActive"
     [routerLink]="link.path"
-    [routerLinkActiveOptions]="{ exact: true }"
   >
     {{ link.label }}
   </a>

--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -1,0 +1,17 @@
+<nav mat-tab-nav-bar [tabPanel]="tabPanel">
+  <a
+    mat-tab-link
+    *ngFor="let link of links"
+    routerLinkActive
+    #rla="routerLinkActive"
+    [active]="rla.isActive"
+    [routerLink]="link.path"
+    [routerLinkActiveOptions]="{ exact: true }"
+  >
+    {{ link.label }}
+  </a>
+</nav>
+<mat-tab-nav-panel #tabPanel></mat-tab-nav-panel>
+<div class="container">
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/admin/admin.component.scss
+++ b/src/app/admin/admin.component.scss
@@ -1,0 +1,3 @@
+.container {
+  margin-top: 1rem;
+}

--- a/src/app/admin/admin.component.spec.ts
+++ b/src/app/admin/admin.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminComponent } from './admin.component';
+
+describe('AdminComponent', () => {
+  let component: AdminComponent;
+  let fixture: ComponentFixture<AdminComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AdminComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+
+interface Links {
+  label: string;
+  path: string;
+}
+
+@Component({
+  selector: 'app-admin',
+  templateUrl: './admin.component.html',
+  styleUrls: ['./admin.component.scss'],
+})
+export class AdminComponent implements OnInit {
+  links: Links[] = [
+    { label: '大会一覧', path: '/admin/league' },
+    { label: '大会登録', path: '/admin/league/add' },
+    { label: 'プレイヤー管理', path: '/admin/player/edit' },
+    { label: '成績管理', path: '/admin/game/edit' },
+  ];
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -12,7 +12,7 @@ interface Links {
 })
 export class AdminComponent implements OnInit {
   links: Links[] = [
-    { label: '大会一覧', path: '/admin/league' },
+    { label: '大会一覧', path: '/admin/league/list' },
     { label: '大会登録', path: '/admin/league/add' },
     { label: 'プレイヤー管理', path: '/admin/player/edit' },
     { label: '成績管理', path: '/admin/game/edit' },

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { OwlDateTimeModule, OwlNativeDateTimeModule } from '@danielmoncada/angular-datetime-picker';
+import { AdminComponent } from './admin.component';
 import { LeagueComponent } from './league/league.component';
 import { LeagueDialogComponent } from './components/league-dialog/league-dialog.component';
 import { GameComponent } from './game/game.component';
@@ -15,6 +16,7 @@ import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   declarations: [
+    AdminComponent,
     LeagueComponent,
     LeagueDialogComponent,
     GameComponent,

--- a/src/app/admin/game/game.component.html
+++ b/src/app/admin/game/game.component.html
@@ -1,20 +1,14 @@
 <mat-card>
   <div class="game">
     <div class="game-header-container">
-      <h2>{{ !formType ? '成績登録' : '成績修正' }}</h2>
-      <div class="move-buttons">
-        <button class="move-buttons__button" mat-stroked-button color="accent" (click)="movePage('details')">
-          大会成績
-        </button>
-        <button class="move-buttons__button" mat-stroked-button color="accent" (click)="movePage('player')">
-          プレイヤー登録
-        </button>
-      </div>
+      <h2>{{ !formType ? '成績管理' : formType === 'post' ? '成績登録' : '成績修正' }}</h2>
+      <ng-container *ngIf="formType === 'put'">
+        <button type="button" mat-stroked-button color="primary" routerLink="/admin/game/edit">成績登録に戻る</button>
+      </ng-container>
     </div>
-
-    <div class="game__option">
+    <div class="game__option" *ngIf="this.selectLeague.value?.id || formType === 'put'">
       <section>
-        <mat-checkbox [checked]="true" (change)="autoCalcPointCheck($event.checked)">自動計算</mat-checkbox>
+        <mat-checkbox [checked]="this.isAutoCalc" (change)="autoCalcPointCheck($event.checked)">自動計算</mat-checkbox>
       </section>
       <mat-form-field appearance="outline">
         <mat-label>合計点チェック</mat-label>
@@ -22,98 +16,92 @@
       </mat-form-field>
     </div>
     <form [formGroup]="formGroup" autocomplete="off" class="formGroup">
-      <ng-container *ngIf="playerList$ | async as playerList">
-        <ng-container formArrayName="gameArray">
-          <ng-container *ngFor="let game of gameArray.controls; let i = index" [formGroupName]="i">
-            <div class="game-grid">
-              <div class="game-grid__rank">
-                <mat-form-field>
-                  <mat-label>ランク</mat-label>
-                  <mat-select formControlName="rank" [errorStateMatcher]="matcher">
-                    <mat-option *ngFor="let _ of gameArray.controls; index as i" [value]="i + 1">
-                      {{ i + 1 }}
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
+      <div classs="league-selector" *ngIf="formType !== 'put'">
+        <mat-form-field class="league-selector__input">
+          <mat-label>大会選択</mat-label>
+          <mat-select [formControl]="selectLeague" [errorStateMatcher]="matcher">
+            <mat-option *ngFor="let league of leagueList$ | async" [value]="league">
+              {{ league.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <ng-container *ngIf="formType">
+        <ng-container *ngIf="playerList$ | async as playerList">
+          <ng-container formArrayName="gameArray">
+            <ng-container *ngFor="let game of gameArray.controls; let i = index" [formGroupName]="i">
+              <div class="game-grid">
+                <div class="game-grid__rank">
+                  <mat-form-field>
+                    <mat-label>ランク</mat-label>
+                    <mat-select formControlName="rank" [errorStateMatcher]="matcher">
+                      <mat-option *ngFor="let _ of gameArray.controls; index as i" [value]="i + 1">
+                        {{ i + 1 }}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
+                <div class="game-grid__name">
+                  <mat-form-field>
+                    <mat-label>名前</mat-label>
+                    <mat-select formControlName="id" [errorStateMatcher]="matcher">
+                      <mat-option *ngFor="let player of playerList" [value]="player.id">
+                        {{ player.name }}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
+                <div class="game-grid__point">
+                  <mat-form-field appearance="outline">
+                    <mat-label>点数</mat-label>
+                    <input
+                      matInput
+                      type="number"
+                      formControlName="point"
+                      [errorStateMatcher]="matcher"
+                      appReplace
+                      maxlength="6"
+                    />
+                  </mat-form-field>
+                </div>
+                <div class="game-grid__calc-point">
+                  <mat-form-field appearance="outline">
+                    <mat-label>順位点</mat-label>
+                    <input
+                      matInput
+                      type="number"
+                      formControlName="calcPoint"
+                      [errorStateMatcher]="matcher"
+                      appReplace
+                      maxlength="4"
+                    />
+                  </mat-form-field>
+                </div>
               </div>
-              <div class="game-grid__name">
-                <mat-form-field>
-                  <mat-label>名前</mat-label>
-                  <mat-select formControlName="id" [errorStateMatcher]="matcher">
-                    <mat-option *ngFor="let player of playerList" [value]="player.id">
-                      {{ player.name }}
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-              <div class="game-grid__point">
-                <mat-form-field appearance="outline">
-                  <mat-label>点数</mat-label>
-                  <input
-                    matInput
-                    type="number"
-                    formControlName="point"
-                    [errorStateMatcher]="matcher"
-                    appReplace
-                    maxlength="6"
-                  />
-                </mat-form-field>
-              </div>
-              <div class="game-grid__calc-point">
-                <mat-form-field appearance="outline">
-                  <mat-label>順位点</mat-label>
-                  <input
-                    matInput
-                    type="number"
-                    formControlName="calcPoint"
-                    [errorStateMatcher]="matcher"
-                    appReplace
-                    maxlength="4"
-                  />
-                </mat-form-field>
-              </div>
-            </div>
+            </ng-container>
           </ng-container>
         </ng-container>
-      </ng-container>
 
-      <div class="game-buttons">
-        <button
-          class="game-buttons__button"
-          (click)="submitGame()"
-          [disabled]="formGroup.invalid"
-          mat-raised-button
-          color="accent"
-        >
-          {{ !formType ? '登録' : '更新' }}
-        </button>
-        <ng-container *ngIf="!formType">
-          <button class="game-buttons__button" (click)="resetForm()" mat-stroked-button color="warn">リセット</button>
-        </ng-container>
-        <ng-container *ngIf="formType === 'put'">
-          <button class="game-buttons__button" (click)="deleteGame()" mat-raised-button color="warn">削除</button>
-        </ng-container>
-      </div>
+        <div class="game-buttons">
+          <ng-container *ngIf="formType === 'post'">
+            <button (click)="postGame()" [disabled]="formGroup.invalid" mat-raised-button color="accent">登録</button>
+            <button (click)="resetForm()" mat-stroked-button color="warn">リセット</button>
+          </ng-container>
+          <ng-container *ngIf="formType === 'put'">
+            <button (click)="putGame()" [disabled]="formGroup.invalid" mat-raised-button color="accent">更新</button>
+            <button (click)="deleteGame()" mat-raised-button color="warn">削除</button>
+          </ng-container>
+        </div>
 
-      <div class="game-table">
-        <app-table
-          *ngIf="gameList$ | async as gameList"
-          (rowClickEvent)="tableRowClick($event)"
-          [columns]="tableColumns"
-          [clickOption]="!this.formType ? true : false"
-          [results]="gameList"
-        ></app-table>
-      </div>
-      <ng-container *ngIf="formType === 'put'">
-        <button
-          type="button"
-          class="game-buttons__button--put"
-          mat-stroked-button
-          color="primary"
-          (click)="movePage('post')"
-        >
-          成績登録に戻る
-        </button>
+        <div class="game-table">
+          <app-table
+            *ngIf="gameList$ | async as gameList"
+            (rowClickEvent)="tableRowClick($event)"
+            [columns]="tableColumns"
+            [clickOption]="!this.formType ? true : false"
+            [results]="gameList"
+          ></app-table>
+        </div>
       </ng-container>
     </form>
   </div>

--- a/src/app/admin/game/game.component.scss
+++ b/src/app/admin/game/game.component.scss
@@ -4,6 +4,7 @@
   &__option {
     display: flex;
     justify-content: space-between;
+    margin-top: 1rem;
   }
   .game-grid {
     display: grid;
@@ -35,12 +36,8 @@
     width: 100%;
     margin-top: 2rem;
     gap: 0.5rem;
-    &__button {
+    button {
       width: 100%;
-      &--put {
-        width: 100%;
-        margin-top: 1rem;
-      }
     }
   }
 }
@@ -50,10 +47,10 @@
   justify-content: space-between;
 }
 
-.move-buttons {
-  display: flex;
-  gap: 0.2rem;
-  margin-bottom: 1rem;
+.league-selector {
+  &__input {
+    width: 100%;
+  }
 }
 
 .game-table {

--- a/src/app/admin/league/league.component.html
+++ b/src/app/admin/league/league.component.html
@@ -1,6 +1,6 @@
 <mat-card>
   <div class="league">
-    <h2>新規大会登録</h2>
+    <h2>大会登録</h2>
     <form [formGroup]="formGroup" autocomplete="off" class="formGroup">
       <div class="league-grid">
         <mat-form-field class="league-grid__input" appearance="outline">

--- a/src/app/admin/my-league/my-league.component.html
+++ b/src/app/admin/my-league/my-league.component.html
@@ -1,9 +1,4 @@
 <mat-card>
-  <h2>大会リスト</h2>
-
-  <button mat-raised-button color="accent" [routerLink]="'/admin/league/add'">
-    <fa-icon transform="left-2 up-2" [icon]="iconFileCirclePlus" size="sm"></fa-icon>大会登録
-  </button>
-
+  <h2>大会一覧</h2>
   <app-league-list *ngIf="leagueList$ | async as leagueList" [leagueList]="leagueList"></app-league-list>
 </mat-card>

--- a/src/app/admin/my-league/my-league.component.scss
+++ b/src/app/admin/my-league/my-league.component.scss
@@ -1,3 +1,0 @@
-button {
-  width: 100%;
-}

--- a/src/app/admin/player/player.component.html
+++ b/src/app/admin/player/player.component.html
@@ -1,36 +1,38 @@
 <mat-card>
   <div class="player">
     <div class="player-header-container">
-      <h2>プレイヤー登録</h2>
-      <div class="move-buttons">
-        <button class="move-buttons__button" mat-stroked-button color="accent" (click)="movePage('details')">
-          大会成績
-        </button>
-        <button class="move-buttons__button" mat-stroked-button color="accent" (click)="movePage('game')">
-          成績管理
-        </button>
-      </div>
+      <h2>プレイヤー管理</h2>
     </div>
-
     <form [formGroup]="formGroup" autocomplete="off" class="formGroup" #form="ngForm">
-      <div class="add-player">
-        <mat-form-field class="add-player__input" appearance="outline">
-          <mat-label>プレイヤー名</mat-label>
-          <input matInput formControlName="name" [errorStateMatcher]="matcher" />
+      <div classs="league-selector">
+        <mat-form-field class="league-selector__input">
+          <mat-label>大会選択</mat-label>
+          <mat-select [formControl]="selectLeague" [errorStateMatcher]="matcher">
+            <mat-option *ngFor="let league of leagueList$ | async" [value]="league">
+              {{ league.name }}
+            </mat-option>
+          </mat-select>
         </mat-form-field>
-        <button
-          class="add-player__button"
-          mat-raised-button
-          color="accent"
-          [disabled]="formGroup.invalid"
-          (click)="postPlayer()"
-        >
-          追加
-        </button>
       </div>
-      <mat-error *ngIf="name.errors?.['maxlength']">10文字以下で入力してください</mat-error>
+      <ng-container *ngIf="selectLeague.value">
+        <div class="add-player">
+          <mat-form-field class="add-player__input" appearance="outline">
+            <mat-label>プレイヤー名</mat-label>
+            <input matInput formControlName="name" [errorStateMatcher]="matcher" />
+          </mat-form-field>
+          <button
+            class="add-player__button"
+            mat-raised-button
+            color="accent"
+            [disabled]="formGroup.invalid"
+            (click)="postPlayer()"
+          >
+            追加
+          </button>
+          <mat-error *ngIf="name.errors?.['maxlength']">10文字以下で入力してください</mat-error>
+        </div>
+        <app-player-list *ngIf="playerList$ | async as playerList" [playerList]="playerList"></app-player-list>
+      </ng-container>
     </form>
-
-    <app-player-list *ngIf="playerList$ | async as playerList" [playerList]="playerList"></app-player-list>
   </div>
 </mat-card>

--- a/src/app/admin/player/player.component.scss
+++ b/src/app/admin/player/player.component.scss
@@ -3,10 +3,10 @@
   justify-content: space-between;
 }
 
-.move-buttons {
-  display: flex;
-  gap: 0.2rem;
-  margin-bottom: 1rem;
+.league-selector {
+  &__input {
+    width: 100%;
+  }
 }
 
 .add-player {

--- a/src/app/admin/player/player.component.ts
+++ b/src/app/admin/player/player.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Subject } from 'rxjs';
-import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { LeagueResponse } from 'src/app/interfaces/league';
+import { LeagueService } from 'src/app/services/league.service';
 import { PlayerRequest } from '../../interfaces/player';
 import { PlayerService } from '../../services/player.service';
 import { MyErrorStateMatcher } from '../../utils/error-state-matcher';
@@ -14,27 +15,30 @@ import { MyErrorStateMatcher } from '../../utils/error-state-matcher';
 })
 export class PlayerComponent implements OnInit, OnDestroy {
   formGroup = new FormGroup({
-    name: new FormControl('', [Validators.required, Validators.pattern(/[\S]/), Validators.maxLength(10)]),
+    name: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.pattern(/[\S]/), Validators.maxLength(10)],
+    }),
   });
   get name() {
     return this.formGroup.get('name') as FormControl;
   }
+  selectLeague = new FormControl<LeagueResponse | null>(null);
+  leagueList$ = this.leagueService.leagueList$;
   playerList$ = this.playerService.playerList$;
   matcher = new MyErrorStateMatcher();
   private onDestroy$ = new Subject<boolean>();
 
-  constructor(private playerService: PlayerService, private activeRoute: ActivatedRoute, private router: Router) {}
+  constructor(private leagueService: LeagueService, private playerService: PlayerService) {}
 
   ngOnInit(): void {
-    this.activeRoute.params
-      .pipe(
-        takeUntil(this.onDestroy$),
-        map((params: Params) => params['league-id']),
-        distinctUntilChanged()
-      )
-      .subscribe((leagueId) => {
-        this.playerService.getPlayerList(leagueId);
-      });
+    this.leagueService.getLeagueList();
+    this.selectLeague.valueChanges.pipe(takeUntil(this.onDestroy$), distinctUntilChanged()).subscribe((league) => {
+      if (!league) {
+        return;
+      }
+      this.playerService.getPlayerList(league.id);
+    });
   }
 
   ngOnDestroy(): void {
@@ -42,27 +46,14 @@ export class PlayerComponent implements OnInit, OnDestroy {
   }
 
   postPlayer() {
-    if (this.formGroup.invalid) {
+    if (this.formGroup.invalid || !this.selectLeague.value) {
       return;
     }
-
     const player: PlayerRequest = {
-      leagueId: String(this.activeRoute.snapshot.paramMap.get('league-id')),
+      leagueId: this.selectLeague.value.id,
       name: this.name.value.trim(),
     };
     this.playerService.postPlayer(player);
     this.name.reset();
-  }
-
-  movePage(value: string) {
-    const id = String(this.activeRoute.snapshot.paramMap.get('league-id'));
-    switch (value) {
-      case 'game':
-        this.router.navigateByUrl(`/admin/game/edit/${id}`);
-        break;
-      case 'details':
-        this.router.navigateByUrl(`/details/${id}`);
-        break;
-    }
   }
 }

--- a/src/app/details/league-details/league-details.component.html
+++ b/src/app/details/league-details/league-details.component.html
@@ -2,30 +2,7 @@
   <div class="league-details" *ngIf="league$ | async as league">
     <div class="details-header-container">
       <h2>{{ league.name }}</h2>
-      <div class="move-buttons">
-        <ng-container *ngIf="user$ | async as user">
-          <ng-container *ngIf="league.uids?.[0]?.uid === user.uid">
-            <button
-              class="move-buttons__button"
-              mat-stroked-button
-              color="accent"
-              routerLink="/admin/player/edit/{{ league.id }}"
-            >
-              プレイヤー管理
-            </button>
-            <button
-              class="move-buttons__button"
-              mat-stroked-button
-              color="accent"
-              routerLink="/admin/game/edit/{{ league.id }}"
-            >
-              成績管理
-            </button>
-          </ng-container>
-        </ng-container>
-      </div>
     </div>
-
     <ng-container *ngIf="league.startAt">
       <p class="league-details__title">大会期間</p>
       <mat-divider></mat-divider>

--- a/src/app/interceptors/notice.interceptor.ts
+++ b/src/app/interceptors/notice.interceptor.ts
@@ -27,7 +27,7 @@ export class NoticeInterceptor implements HttpInterceptor {
       }),
       catchError((err) => {
         this.snack.openSnackBer('エラーが発生しました.', '✖️');
-        this.router.navigateByUrl(`/admin/league`);
+        this.router.navigateByUrl(`/admin/league/list`);
         return throwError(() => err);
       })
     );

--- a/src/app/interceptors/token.interceptor.ts
+++ b/src/app/interceptors/token.interceptor.ts
@@ -29,7 +29,6 @@ export class TokenInterceptor implements HttpInterceptor {
             setHeaders: {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${token}`,
-              LeagueID: this.getLeagueIdByURL(this.router.routerState.snapshot.url),
             },
           });
           return next.handle(req);
@@ -37,15 +36,5 @@ export class TokenInterceptor implements HttpInterceptor {
         return next.handle(request);
       })
     );
-  }
-
-  //URLからleagueIDを取得する関数
-  getLeagueIdByURL(url: string) {
-    //'edit/'後の開始位置
-    const start = url.indexOf('edit/') + 5;
-    //uuid後の終了位置
-    const finish = start + 32;
-    const id = url.substring(start, finish);
-    return !id ? '' : id;
   }
 }

--- a/src/app/material.module.ts
+++ b/src/app/material.module.ts
@@ -19,6 +19,8 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatTabsModule } from '@angular/material/tabs';
 
 @NgModule({
   declarations: [],
@@ -43,6 +45,8 @@ import { MatCardModule } from '@angular/material/card';
     MatSortModule,
     MatTableModule,
     MatCardModule,
+    MatDatepickerModule,
+    MatTabsModule,
   ],
 })
 export class MaterialModule {}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -51,7 +51,7 @@ export class AuthService {
     signInWithEmailAndPassword(this.auth, user.mail, user.password)
       .then((result) => {
         this.userSubject.next(result.user);
-        this.router.navigateByUrl('/admin/league');
+        this.router.navigateByUrl('/admin/league/list');
       })
       .catch(() => this.snack.openSnackBer('Error', 'x'))
       .finally(() => {

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -60,35 +60,18 @@ export class GameService {
     this.http
       .put<GameResponse>(`${this.apiUrl}/${id}`, game)
       .pipe()
-      .subscribe((res) => {
-        this.gameListSubject.next(
-          this.gameListSubject.getValue().map((game) => {
-            if (game.id === res.id) {
-              return res;
-            } else {
-              return game;
-            }
-          })
-        );
-        this.route.navigateByUrl(`/admin/game/edit/${res.leagueId}`);
+      .subscribe(() => {
+        this.route.navigateByUrl(`/admin/game/edit`);
       });
   }
 
   //ゲーム削除
-  deleteGame(id: number, leagueId: string): void {
+  deleteGame(id: number): void {
     this.http
       .delete<GameResponse>(`${this.apiUrl}/${id}`)
       .pipe()
-      .subscribe((res) => {
-        const newArray = this.gameListSubject.getValue().filter((game) => {
-          if (game.id !== res.id) {
-            return game;
-          } else {
-            return null;
-          }
-        });
-        this.gameListSubject.next(newArray);
-        this.route.navigateByUrl(`/admin/game/edit/${leagueId}`);
+      .subscribe(() => {
+        this.route.navigateByUrl(`/admin/game/edit`);
       });
   }
 }

--- a/src/app/services/league.service.ts
+++ b/src/app/services/league.service.ts
@@ -70,7 +70,7 @@ export class LeagueService {
       .post<LeagueResponse>(`${this.apiUrl}`, newleague)
       .pipe()
       .subscribe(() => {
-        this.route.navigateByUrl('/admin/league');
+        this.route.navigateByUrl('/admin/league/list');
       });
   }
 

--- a/src/app/shared/components/menu-list/menu-list.component.html
+++ b/src/app/shared/components/menu-list/menu-list.component.html
@@ -1,5 +1,5 @@
 <div class="menu-list">
-  <button mat-menu-item routerLink="/admin/league"><mat-icon>home</mat-icon>MyLeague</button>
+  <button mat-menu-item routerLink="/admin/league/list"><mat-icon>home</mat-icon>マイページ</button>
   <button mat-menu-item routerLink=""><mat-icon>settings</mat-icon>設定</button>
   <button mat-menu-item (click)="logout()"><mat-icon>logout</mat-icon>ログアウト</button>
 </div>


### PR DESCRIPTION
## Issue
#208

## 新規/変更内容
管理者用の基点を作成し、画面遷移をするnav-linkを作成
リーグ選択からプレイヤー、ゲームを登録できるように変更
LeagueHeaderを廃止する

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [x] はい
- [ ] いいえ
