### PR TITLE
FooterのSNS-linkがテーマ変更時色が変わってしまう修正

### DIFF
--- a/src/app/shared/components/footer/footer.component.scss
+++ b/src/app/shared/components/footer/footer.component.scss
@@ -22,6 +22,7 @@
   &__link {
     grid-column: 2 / 3;
     grid-row: 1 / 2;
+    color: var.$dark-font-color;
     @include mixin.center;
   }
 }


### PR DESCRIPTION
## Issue
#233

## 新規/変更内容
FooterのSNS-linkがテーマ変更時色が変わってしまうため
色を上書きすることで対応

## タスク
- [x] [GitHubRules](https://gist.github.com/CatBloom/d15b7e26705dd801787a69996d72669f)を確認する

## 変更の影響範囲は大きいですか？
- [ ] はい
- [x] いいえ
